### PR TITLE
docs: new documentation structure

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,9 +3,10 @@ Authors
 
 The list of contributors in alphabetical order:
 
-- `Adam Novorolnik <https://github.com/ANovorolnik>`_
-- `Alex Mieth <https://github.com/AlexMieth>`_
-- `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_
-- `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_
-- `Parth Shandilya <https://github.com/ParthS007>`_
-- `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_
+- Adam Novorolnik (`@ANovorolnik <https://github.com/ANovorolnik>`_)
+- Alex Mieth (`@AlexMieth <https://github.com/AlexMieth>`_)
+- `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_ (`@dprelipcean <https://github.com/dprelipcean>`_)
+- `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_ (`@okraskaj <https://github.com/okraskaj>`_)
+- Jiri Kuncar (`@jirikuncar <https://github.com/jirikuncar>`_)
+- Parth Shandilya (`@ParthS007 <https://github.com/ParthS007>`_)
+- `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_ (`@tiborsimko <https://github.com/tiborsimko>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,15 +1,7 @@
 Changes
 =======
 
-Version 0.1.0 (2019-MM-DD)
+Version 0.1.0 (2020-MM-DD)
 --------------------------
-.. TODO add realease date
 
 - Initial public release.
-
-.. admonition:: Please beware
-
-   Please note that cernopendata-client is in an early alpha stage of
-   its development. The developer preview releases are meant for early
-   adopters and testers. Please don't rely on released versions for any
-   production purposes yet.

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-=========================
- CERN Open Data - Client
-=========================
+###################
+cernopendata-client
+###################
 
 .. image:: https://img.shields.io/pypi/pyversions/cernopendata-client.svg
    :target: https://pypi.org/pypi/cernopendata-client
@@ -23,55 +23,27 @@
 About
 =====
 
-The CERN Open Data Client is a command line tool used to better facilitate
-the individual acquisition of files from the
-`CERN Open Data Portal <http://opendata.cern.ch/>`_.
-The tool uses the portal's API to query a given Open Data record
-and automatically download the files listed on that record.
-In its current form, the tool can only be used for analysis records like the
-`Higgs-to-four-lepton analysis example <http://opendata.cern.ch/record/5500/>`_,
-but it should be generalized in the future to work for any type
-of Open Data portal record.
+``cernopendata-client`` is a command-like tool to facilitate downloading files
+from the `CERN Open Data portal <http://opendata.cern.ch/>`_. The tool enables
+to query datasets hosted on the CERN Open Data portal and to download and
+verify the individual data set files.
 
+Installation
+============
+
+.. code-block:: console
+
+    $ pip install cernopendata-client
 
 Usage
 =====
 
-To use this command line tool simply run the program from the command lin
-using python as shown below. The program requires the user to provide
-a CERN Open Data portal record number using the ``-r`` flag.
-The record number of a Open Data portal record is simply found at the end of
-the URL for that record (e.g. the record number for the Two-lepton/four-lepton
-analysis example found at http://opendata.cern.ch/record/101 is simply 101.
+The detailed information on how to install and use `cernopendata-client` can be
+found in `cernopendata-client.readthedocs.io
+<https://cernopendata-client.readthedocs.io/en/latest/>`_.
 
-.. code-block:: console
+Useful links
+============
 
-    $ python opendata_analysis_query.py -r 101
-
-The program will then begin querying the provided analysis record and
-automatically downloading all of the index files listed within the dataset
-links under the **Use With** section of the record. The program provides some
-output informing the user of the completion of all the downloads as well as the
-name of the directory where these downloads can be found. If the command above
-runs successfully, you should see something like this:
-
-
-.. code-block:: console
-
-    Getting index files for 'Two-lepton/four-lepton analysis example of CMS 2010 open data'...
-
-    Downloaded 1 index files from Electron/Run2010B-Apr21ReReco-v1
-    Downloaded 1 index files from Mu/Run2010B-Apr21ReReco-v1
-
-    Query Complete: Downloaded 2 index files to the folder ./rec101_datasets/
-
-
-Development Notes
-=================
-
-Please see comments within the python script (opendata_analysis_query.py)
- for detailed descriptions of what the script does.
-
-The script uses the `Requests <http://docs.python-requests.org/en/master/>`_
-python library to send HTTP requests and verify that each request is ok using
-the built in raise_for_status() method.
+- `CERN Open Data portal <http://opendata.cern.ch/>`_
+- `CERN Open Data user forum <https://opendata-forum.cern.ch/>`_

--- a/docs/cliapi.rst
+++ b/docs/cliapi.rst
@@ -1,0 +1,6 @@
+CLI API
+=======
+
+.. click:: cernopendata_client.cli:cernopendata_client
+   :prog: cernopendata-client
+   :show-nested:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,17 +96,18 @@ html_theme = "alabaster"
 #
 html_theme_options = {
     "logo": "logo-cernopendata-client.png",
-    "description": """<p>The CERN Open Data Client is a command line tool to 
-                      interact with CERN Open Data API.</p>""",
+    "description": """<p>The cernopendata-client is a command-line tool to
+                      interact with the CERN Open Data portal.</p>""",
     "github_user": "cernopendata",
     "github_repo": "cernopendata-client",
     "github_button": False,
     "github_banner": True,
     "show_powered_by": False,
     "extra_nav_links": {
-        "COD@GitHub": "https://github.com/cernopendata",
-        "COD@Twitter": "https://twitter.com/cernopendata",
-        "COD@Web": "http://opendata.cern.ch//",
+        "cernopendata@GitHub": "https://github.com/cernopendata",
+        "cernopendata@Twitter": "https://twitter.com/cernopendata",
+        "opendata-forum.cern.ch": "https://opendata-forum.cern.ch/",
+        "opendata.cern.ch": "http://opendata.cern.ch/",
     },
 }
 
@@ -163,7 +164,7 @@ latex_documents = [
     (
         master_doc,
         "cernopendata_client.tex",
-        "CERN Open Data Client Documentation",
+        "cernopedata-client documentation",
         "CERN Open Data",
         "manual",
     ),
@@ -178,7 +179,7 @@ man_pages = [
     (
         master_doc,
         "cernopendata_client",
-        "CERN Open Data Client Documentation",
+        "cernopendata-client documentation",
         [author],
         1,
     )
@@ -194,10 +195,10 @@ texinfo_documents = [
     (
         master_doc,
         "cernopendata_client",
-        "CERN Open Data Client Documentation",
+        "cernopendata-client documentation",
         author,
-        "cernopendata_client",
-        "Command line tool to interact with CERN Open Data API.",
+        "cernopendata-client",
+        "Command-line tool to interact with the CERN Open Data portal.",
         "Miscellaneous",
     ),
 ]

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,7 +5,7 @@ Issues
 ------
 
 Bug reports, feature requests, and other contributions are welcome. If you find
-a demonstrable problem that is caused by the cernopendata_client code, please:
+a demonstrable problem that is caused by the ``cernopendata-client`` code, please:
 
 1. Search for `already reported problems
    <https://github.com/cernopendata/cernopendata-client/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,17 @@
 .. include:: ../README.rst
+   :end-before: About
+
+.. include:: ../README.rst
+   :start-after: =====
+   :end-before: Installation
 
 .. toctree::
    :numbered:
 
-   userguide
-   contributing
+   installation
+   usage
+   cliapi
    changes
+   contributing
    license
    authors

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,18 @@
+Installation
+============
+
+``cernopendata-client`` is available on PyPI.
+
+You can install it into your personal user space by doing:
+
+.. code-block:: console
+
+   $ pip install --user cernopendata-client
+
+or into a new virtual environment:
+
+.. code-block:: console
+
+   $ virtualenv ~/.virtualenvs/cernopendata-client
+   $ source ~/.virtualenvs/cernopendata-client/bin/activate
+   $ pip install cernopendata-client

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,8 +1,10 @@
 License
 =======
 
-.. literalinclude:: ../LICENSE
+``cernopendata-client`` is available under the GNU General Public License.
 
 In applying this license, CERN does not waive the privileges and immunities
 granted to it by virtue of its status as an Intergovernmental Organization or
 submit itself to any jurisdiction.
+
+.. literalinclude:: ../LICENSE

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,25 +1,7 @@
 .. _gettingstarted:
 
-User Guide
-===============
-
-Install cernopendata-client
----------------------------
-
-If you are interested in exploring resources of opendata.cern.ch from cli,
-all you need to install is the ``cernopendata-client``,
-ideally in a new virtual environment:
-
-.. code-block:: console
-
-   $ # create new virtual environment
-   $ virtualenv ~/.virtualenvs/cernopendata_client
-   $ source ~/.virtualenvs/cernopendata_client/bin/activate
-   $ # install cernopendata-client
-   $ pip install cernopendata-client
-
-Basic usage
------------
+Usage
+=====
 
 .. code-block:: console
 
@@ -52,15 +34,3 @@ Basic usage
     $ # with --protocol option:
     $ cernopendata-client get-file-locations --recid 43 --protocol http
     $ ...
-
-
-CLI API
--------
-
-.. click:: cernopendata_client.cli:get_record
-   :prog: get_record
-   :show-nested:
-
-.. click:: cernopendata_client.cli:get_file_locations
-   :prog: get_file_locations
-   :show-nested:


### PR DESCRIPTION
Amends documentation structure and removes the old help that is not
valid anymore. Closes #10.

Amends author list and other minor textual changes. The user guide is
to be updated separately still.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>