### PR TITLE
searcher: fix record selection by DOI

### DIFF
--- a/cernopendata_client/search.py
+++ b/cernopendata_client/search.py
@@ -60,6 +60,7 @@ def get_recid(server=None, title=None, doi=None):
         name, value = "doi", doi
     url = (
         server
+        + "/api/records"
         + "?page=1&size=1&q={}:".format(name)
         + quote('"{}"'.format(value), safe="")
     )

--- a/tests/test_cli_get_file_locations.py
+++ b/tests/test_cli_get_file_locations.py
@@ -13,9 +13,38 @@ from click.testing import CliRunner
 from cernopendata_client.cli import get_file_locations
 
 
-def test_get_file_locations():
-    """Test get-file-locations command."""
+def test_get_file_locations_from_recid():
+    """Test `get-file-locations --recid` command."""
     test_get_file_locations = CliRunner()
     test_result = test_get_file_locations.invoke(get_file_locations, ["--recid", 3005])
     assert test_result.exit_code == 0
     assert "0d0714743f0204ed3c0144941e6ce248.configFile.py" in test_result.output
+
+
+def test_get_file_locations_from_recid_wrong():
+    """Test `get-file-locations --recid` command for wrong values."""
+    test_get_file_locations = CliRunner()
+    test_result = test_get_file_locations.invoke(get_file_locations, ["--recid", 0])
+    assert test_result.exit_code == 2
+
+
+def test_get_file_locations_from_doi():
+    """Test `get-file-locations --doi` command."""
+    test_get_file_locations = CliRunner()
+    test_result = test_get_file_locations.invoke(
+        get_file_locations, ["--doi", "10.7483/OPENDATA.CMS.A342.9982", "--no-expand"]
+    )
+    assert test_result.exit_code == 0
+    assert (
+        "CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0001_file_index.json"
+        in test_result.output
+    )
+
+
+def test_get_file_locations_from_doi_wrong():
+    """Test `get-file-locations --doi` command for wrong values."""
+    test_get_file_locations = CliRunner()
+    test_result = test_get_file_locations.invoke(
+        get_file_locations, ["--doi", "NONEXISTING", "--no-expand"]
+    )
+    assert test_result.exit_code == 2

--- a/tests/test_cli_get_metadata.py
+++ b/tests/test_cli_get_metadata.py
@@ -13,8 +13,8 @@ from click.testing import CliRunner
 from cernopendata_client.cli import get_metadata
 
 
-def test_get_metadata():
-    """Test get-metadata command."""
+def test_get_metadata_from_recid():
+    """Test `get-metadata --recid` command."""
     test_get_metadata = CliRunner()
     test_result = test_get_metadata.invoke(get_metadata, ["--recid", 3005])
     assert test_result.exit_code == 0
@@ -22,3 +22,27 @@ def test_get_metadata():
         '"title": "Configuration file for LHE step HIG-Summer11pLHE-00114_1_cfg.py"'
         in test_result.output
     )
+
+
+def test_get_metadata_from_recid_wrong():
+    """Test `get-metadata --recid` command for wrong values."""
+    test_get_metadata = CliRunner()
+    test_result = test_get_metadata.invoke(get_metadata, ["--recid", 0])
+    assert test_result.exit_code == 2
+
+
+def test_get_metadata_from_doi():
+    """Test `get-metadata --doi` command."""
+    test_get_metadata = CliRunner()
+    test_result = test_get_metadata.invoke(
+        get_metadata, ["--doi", "10.7483/OPENDATA.CMS.A342.9982"]
+    )
+    assert test_result.exit_code == 0
+    assert '"title": "/BTau/Run2010B-Apr21ReReco-v1/AOD"' in test_result.output
+
+
+def test_get_metadata_from_doi_wrong():
+    """Test `get-metadata --doi` command for wrong values."""
+    test_get_metadata = CliRunner()
+    test_result = test_get_metadata.invoke(get_metadata, ["--doi", "NONEXISTING"])
+    assert test_result.exit_code == 2


### PR DESCRIPTION
Fixes record selection by DOI.

Adds tests for metadata and file location lookup to prevent this
regression from reappearing in the future.

Closes #39.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>