### PR TITLE
docs: autodoc_mock_imports for pycurl

### DIFF
--- a/docs/cliapi.rst
+++ b/docs/cliapi.rst
@@ -3,6 +3,9 @@
 CLI API
 =======
 
+Please use ``cernopendata-client --help`` in your terminal shell to learn about
+all commands and their options.
+
 .. click:: cernopendata_client.cli:cernopendata_client
    :prog: cernopendata-client
    :show-nested:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,9 @@ extensions = [
     "sphinx_click.ext",
 ]
 
+# Autodoc mocking to fix ReadTheDocs builds missing system dependencies
+autodoc_mock_imports = ["pycurl"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,5 @@
--e .[all]
+click>=7,<8
+requests==2.22.0
+Sphinx>=1.4.4,<2.0
+sphinx-click>=1.0.4
+sphinx-rtd-theme>=0.1.9


### PR DESCRIPTION
Adds mocking of `pycurl` that cannot be installed on ReadTheDocs
builders.  However, we would also have to remove `pycurl` as the
installation dependency of `cernopendata-client` in `setup.py`, which
is not wanted at this stage.

Hence amends CLI API page to simply instruct persons to use command
line to get the list of all commands and options. It is better to
show latest user guide instead.

This fixes the ReadTheDocs building problem.

Addresses #40.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>