### PR TITLE
docker: initial release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ notifications:
 
 sudo: true
 
+services:
+  - docker
+
 language: python
 
 cache:
@@ -35,6 +38,8 @@ install:
 
 script:
   - ./run-tests.sh
+  - docker build -t cernopendata/cernopendata-client .
+  - docker run --rm cernopendata/cernopendata-client version
 
 after_success:
   - coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# This file is part of cernopendata-client.
+#
+# Copyright (C) 2020 CERN.
+#
+# cernopendata-client is free software; you can redistribute it and/or modify
+# it under the terms of the GPLv3 license; see LICENSE file for more details.
+
+# Use Python 3.8 slim base image
+FROM python:3.8-slim
+
+# Install system prerequisites
+RUN apt-get update -y && \
+    apt-get install -y \
+        curl \
+        gcc \
+        libcurl4-openssl-dev \
+        libssl-dev && \
+    apt-get autoremove && \
+    apt-get clean
+
+# Add sources to `/code` and work there
+WORKDIR /code
+ADD . /code
+
+# Install cernopendata-client
+RUN pip install .
+
+# Remove /code to make image slimmer
+RUN rm -rf /code
+
+# Run container as `cernopendata` user with UID `1000`, which should match
+# current host user in most situations
+RUN adduser --uid 1000 --disabled-password --gecos '' cernopendata
+
+# Run cernopendata-client upon entry
+USER cernopendata
+ENTRYPOINT ["cernopendata-client"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,10 @@
-include LICENSE
 include *.rst
 include *.sh
+include Dockerfile
+include LICENSE
+include docs/requirements.txt
 include pytest.ini
 include tox.ini
-include docs/requirements.txt
 prune docs/_build
 recursive-include cernopendata_client *.py
 recursive-include docs *.png

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,18 +1,30 @@
 Installation
 ============
 
-``cernopendata-client`` is available on PyPI.
+PyPI
+----
 
-You can install it into your personal user space by doing:
+``cernopendata-client`` is available on PyPI. You can install it into your
+personal user space by doing:
 
 .. code-block:: console
 
    $ pip install --user cernopendata-client
 
-or into a new virtual environment:
+You can also install it into a new virtual environment:
 
 .. code-block:: console
 
    $ virtualenv ~/.virtualenvs/cernopendata-client
    $ source ~/.virtualenvs/cernopendata-client/bin/activate
    $ pip install cernopendata-client
+
+Docker
+------
+
+If you would like to use ``cernopendata-client`` as a standalone Docker
+container, you can pull an image as follows:
+
+.. code-block:: console
+
+   $ docker pull cernopendata/cernopendata-client


### PR DESCRIPTION
Adds `Dockerfile` so that users interested in running
`cernopendata-client` via Docker containers can do so.  Useful for
example for old CMSSW legacy environments. Usage example:

$ docker run --rm cernopendata-client get-file-locations --recid 5500

Amends Travis CI test suite accordingly.

Sorts `MANIFEST.in` alphabetically.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>