### PR TITLE
printer: simplify usage and standardise colouring

### DIFF
--- a/cernopendata_client/cli.py
+++ b/cernopendata_client/cli.py
@@ -96,7 +96,6 @@ def get_metadata(server, recid, doi, title, output_value):
                 output_json = output_json[field]
             except (KeyError, TypeError):
                 display_message(
-                    prefix="double",
                     msg_type="error",
                     msg="Field '{}' is not present in metadata".format(field),
                 )
@@ -248,7 +247,6 @@ def download_files(
     if names or regexp or ranges:
         if not download_file_locations:
             display_message(
-                prefix="double",
                 msg_type="error",
                 msg="No files matching the filters",
             )
@@ -267,13 +265,11 @@ def download_files(
             os.mkdir(path)
         except OSError:
             display_message(
-                prefix="double",
                 msg_type="error",
                 msg="Creation of the directory {} failed".format(path),
             )
     for file_location in download_file_locations:
         display_message(
-            prefix="double",
             msg_type="info",
             msg="Downloading file {} of {}".format(
                 download_file_locations.index(file_location) + 1, total_files
@@ -290,8 +286,7 @@ def download_files(
             file_info_local = get_file_info_local(recid)
             verify_file_info(file_info_local, file_info_remote)
     display_message(
-        prefix="double",
-        msg_type="success",
+        msg_type="info",
         msg="Success!",
     )
 
@@ -327,7 +322,6 @@ def verify_files(server, recid):
     file_info_local = get_file_info_local(recid)
     if not file_info_local:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="No local files found for record {}. Perhaps run `download-files` first? Exiting.".format(
                 recid
@@ -337,17 +331,15 @@ def verify_files(server, recid):
 
     # Verify number of files
     display_message(
-        prefix="double",
         msg_type="info",
         msg="Verifying number of files for record {}... ".format(recid),
     )
     display_message(
-        prefix="single",
-        msg="expected {}, found {}".format(len(file_info_remote), len(file_info_local)),
+        msg_type="note",
+        msg="Expected {}, found {}".format(len(file_info_remote), len(file_info_local)),
     )
     if len(file_info_remote) != len(file_info_local):
         display_message(
-            prefix="double",
             msg_type="error",
             msg="File count does not match.",
         )
@@ -358,7 +350,6 @@ def verify_files(server, recid):
 
     # Success!
     display_message(
-        prefix="double",
-        msg_type="success",
+        msg_type="info",
         msg="Success!",
     )

--- a/cernopendata_client/config.py
+++ b/cernopendata_client/config.py
@@ -15,11 +15,11 @@ SERVER_HTTP_URI = "http://opendata.cern.ch"
 SERVER_ROOT_URI = "root://eospublic.cern.ch/"
 """Default CERN Open Data server to query over XRootD protocol."""
 
-PRINTER_COLOUR_INFO = "bright_yellow"
-"""Default Color for info message on terminal"""
+PRINTER_COLOUR_INFO = "green"
+"""Default colour for info messages on terminal."""
 
-PRINTER_COLOUR_ERROR = "bright_red"
-"""Default Color for error message on terminal"""
+PRINTER_COLOUR_NOTE = "blue"
+"""Default colour for note messages on terminal."""
 
-PRINTER_COLOUR_SUCCESS = "bright_green"
-"""Default Color for success message on terminal"""
+PRINTER_COLOUR_ERROR = "red"
+"""Default colour for error messages on terminal."""

--- a/cernopendata_client/downloader.py
+++ b/cernopendata_client/downloader.py
@@ -35,12 +35,13 @@ def show_download_progress(
 ):
     """Show download progress of a file."""
     kb = 1024
-    sys.stdout.write(
-        "  -> Progress: {}/{} kiB ({}%)\r".format(
+    display_message(
+        msg_type="progress",
+        msg="Progress: {}/{} kiB ({}%)\r".format(
             str(int(download_d / kb)),
             str(int(download_t / kb)),
             str(int(download_d / download_t * 100) if download_t > 0 else 0),
-        )
+        ),
     )
     sys.stdout.flush()
 
@@ -52,7 +53,7 @@ def download_single_file(path=None, file_location=None, protocol=None):
         file_dest = path + "/" + file_name
         with open(file_dest, "wb") as f:
             display_message(
-                prefix="single",
+                msg_type="note",
                 msg="File: ./{}/{}".format(
                     path,
                     file_name,
@@ -85,7 +86,6 @@ def download_single_file(path=None, file_location=None, protocol=None):
     elif protocol == "xrootd":
         if not xrootd_available:
             display_message(
-                prefix="double",
                 msg_type="error",
                 msg="xrootd is not installed on system. Please use the 'http' protocol instead.",
             )
@@ -96,7 +96,7 @@ def download_single_file(path=None, file_location=None, protocol=None):
         fs = XRootDPyFS("root://eospublic.cern.ch//")
         with open(file_dest, "wb") as dest, fs.open(file_src, "rb") as src:
             display_message(
-                prefix="single",
+                msg_type="note",
                 msg="File: ./{}/{}".format(
                     path,
                     file_name,

--- a/cernopendata_client/printer.py
+++ b/cernopendata_client/printer.py
@@ -10,40 +10,41 @@
 
 import click
 
-from .config import PRINTER_COLOUR_ERROR, PRINTER_COLOUR_INFO, PRINTER_COLOUR_SUCCESS
+from .config import PRINTER_COLOUR_ERROR, PRINTER_COLOUR_INFO, PRINTER_COLOUR_NOTE
 
 
-def display_message(prefix=None, msg_type=None, msg=None):
+def display_message(msg_type=None, msg=None):
     """Display message in a similar style as run_command().
 
-    :param prefix: prefix to be added in output (==> / ->)
-    :param msg_type: Type of message - Error/Progress/Success
+    :param msg_type: Type of message (info/note/error)
     :param msg: message to display
-    :type prefix: str
     :type msg_type: str
     :type msg: str
     """
     msg_color_map = {
         "info": PRINTER_COLOUR_INFO,
+        "note": PRINTER_COLOUR_NOTE,
+        "progress": PRINTER_COLOUR_NOTE,
         "error": PRINTER_COLOUR_ERROR,
-        "success": PRINTER_COLOUR_SUCCESS,
     }
-    msg_color = msg_color_map.get(msg_type, None)
+    msg_color = msg_color_map.get(msg_type, "")
 
-    if prefix == "double":
-        if msg_color:
-            click.secho("==> ", bold=True, nl=False, fg="{}".format(msg_color))
-        if msg_type == "error":
-            click.secho(
-                "{}: ".format(msg_type.upper()),
-                bold=True,
-                nl=False,
-                fg=PRINTER_COLOUR_ERROR,
-            )
-    elif prefix == "single":
-        click.secho("  -> ", bold=False, nl=False)
-
-    if msg_color:
-        click.secho("{}".format(msg), bold=True, nl=True, fg="{}".format(msg_color))
-    else:
+    if msg_type == "info":
+        click.secho("==> ", bold=True, nl=False, fg="{}".format(msg_color))
+        click.secho("{}".format(msg), bold=True, nl=True)
+    elif msg_type == "note":
+        click.secho("  -> ", bold=False, nl=False, fg="{}".format(msg_color))
         click.secho("{}".format(msg), bold=False, nl=True)
+    elif msg_type == "progress":
+        click.secho("  -> ", bold=False, nl=False, fg="{}".format(msg_color))
+        click.secho("{}".format(msg), bold=False, nl=False)
+    elif msg_type == "error":
+        click.secho(
+            "==> {}: ".format(msg_type.upper()),
+            bold=True,
+            nl=False,
+            fg="{}".format(msg_color),
+        )
+        click.secho("{}".format(msg), bold=False, nl=True)
+    else:
+        click.secho("{}".format(msg), nl=True)

--- a/cernopendata_client/searcher.py
+++ b/cernopendata_client/searcher.py
@@ -48,7 +48,6 @@ def verify_recid(server=None, recid=None):
             input_record_url_check.raise_for_status()
         except requests.HTTPError:
             display_message(
-                prefix="double",
                 msg_type="error",
                 msg="The record id number you supplied is not valid.",
             )
@@ -102,7 +101,6 @@ def get_recid(server=None, title=None, doi=None):
         response.raise_for_status()
     except requests.HTTPError as e:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="Connection to server failed: \n reason: {}.".format(e),
         )
@@ -110,14 +108,12 @@ def get_recid(server=None, title=None, doi=None):
         hits_total = response_json["hits"]["total"]
         if hits_total < 1:
             display_message(
-                prefix="double",
                 msg_type="error",
                 msg="Record with given {} does not exist.".format(name),
             )
             sys.exit(2)
         elif hits_total > 1:
             display_message(
-                prefix="double",
                 msg_type="error",
                 msg="More than one record fit this {}."
                 "This should not happen.".format(name),
@@ -150,7 +146,6 @@ def get_record_as_json(server=None, recid=None, doi=None, title=None):
         record_id = get_recid(server=server, doi=doi)
     else:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="Please provide at least one of following arguments: "
             "(recid, doi, title)",

--- a/cernopendata_client/utils.py
+++ b/cernopendata_client/utils.py
@@ -28,7 +28,6 @@ def parse_parameters(filter_input):
         return filters
     except Exception:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="{} - Wrong input format".format(filter_input),
         )

--- a/cernopendata_client/validator.py
+++ b/cernopendata_client/validator.py
@@ -25,14 +25,12 @@ def validate_recid(recid=None):
     """
     if recid is None:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="You must supply a record id number as an " "input using -r flag.",
         )
         sys.exit(1)
     if recid <= 0:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="Invalid value for {}: {} - Recid should be a positive integer".format(
                 "--recid", recid
@@ -53,7 +51,6 @@ def validate_server(server=None):
     """
     if not server.startswith("http://"):
         display_message(
-            prefix="double",
             msg_type="error",
             msg="Invalid value for {}: {} - Server should be a valid HTTP URI".format(
                 "--server", server
@@ -78,7 +75,6 @@ def validate_range(range=None, count=None):
         range_from, range_to = int(range.split("-")[0]), int(range.split("-")[-1])
     except Exception:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="Invalid value for {}: {} - Range should have start and end index(i-j)".format(
                 "--filter-range", range
@@ -87,7 +83,6 @@ def validate_range(range=None, count=None):
         sys.exit(2)
     if range_from <= 0:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="Invalid value for {}: {} - Range should start from a positive integer".format(
                 "--filter-range", range_from
@@ -96,7 +91,6 @@ def validate_range(range=None, count=None):
         sys.exit(2)
     if range_to > count:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="Invalid value for {}: {} - Range is too big. There are total {} files".format(
                 "--filter-range", range, count
@@ -105,7 +99,6 @@ def validate_range(range=None, count=None):
         sys.exit(2)
     if range_to < range_from:
         display_message(
-            prefix="double",
             msg_type="error",
             msg="Invalid value for {}: {} - Range is not valid".format(
                 "--filter-range", range

--- a/cernopendata_client/verifier.py
+++ b/cernopendata_client/verifier.py
@@ -92,28 +92,24 @@ def verify_file_info(file_info_local, file_info_remote):
                 bfile_checksum = bfile_info_local["checksum"]
                 break
         display_message(
-            prefix="double",
             msg_type="info",
             msg="Verifying file {}... ".format(afile_name),
         )
         display_message(
-            prefix="single",
-            msg="expected size {}, found {}".format(afile_size, bfile_size),
+            msg_type="note",
+            msg="Expected size {}, found {}".format(afile_size, bfile_size),
         )
         if afile_size != bfile_size:
             display_message(
-                prefix="double",
                 msg_type="error",
                 msg="File size does not match.",
             )
             sys.exit(1)
         display_message(
-            prefix="single",
-            msg="expected checksum {}, found {}".format(afile_checksum, bfile_checksum),
+            msg_type="note",
+            msg="Expected checksum {}, found {}".format(afile_checksum, bfile_checksum),
         )
         if afile_checksum != bfile_checksum:
-            display_message(
-                prefix="double", msg_type="error", msg="File checksum does not match."
-            )
+            display_message(msg_type="error", msg="File checksum does not match.")
             sys.exit(1)
     return True

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -331,40 +331,40 @@ use the **verify-files** command:
 
     $ cernopendata-client verify-files --recid 5500
     ==> Verifying number of files for record 5500...
-      -> expected 11, found 11
+      -> Expected 11, found 11
     ==> Verifying file BuildFile.xml...
-      -> expected size 305, found 305
-      -> expected checksum adler32:ff63668a, found adler32:ff63668a
+      -> Expected size 305, found 305
+      -> Expected checksum adler32:ff63668a, found adler32:ff63668a
     ==> Verifying file HiggsDemoAnalyzer.cc...
-      -> expected size 83761, found 83761
-      -> expected checksum adler32:f205f068, found adler32:f205f068
+      -> Expected size 83761, found 83761
+      -> Expected checksum adler32:f205f068, found adler32:f205f068
     ==> Verifying file List_indexfile.txt...
-      -> expected size 1669, found 1669
-      -> expected checksum adler32:46a907fc, found adler32:46a907fc
+      -> Expected size 1669, found 1669
+      -> Expected checksum adler32:46a907fc, found adler32:46a907fc
     ==> Verifying file M4Lnormdatall.cc...
-      -> expected size 14943, found 14943
-      -> expected checksum adler32:af301992, found adler32:af301992
+      -> Expected size 14943, found 14943
+      -> Expected checksum adler32:af301992, found adler32:af301992
     ==> Verifying file M4Lnormdatall_lvl3.cc...
-      -> expected size 15805, found 15805
-      -> expected checksum adler32:9d9b2126, found adler32:9d9b2126
+      -> Expected size 15805, found 15805
+      -> Expected checksum adler32:9d9b2126, found adler32:9d9b2126
     ==> Verifying file demoanalyzer_cfg_level3MC.py...
-      -> expected size 3741, found 3741
-      -> expected checksum adler32:cc943381, found adler32:cc943381
+      -> Expected size 3741, found 3741
+      -> Expected checksum adler32:cc943381, found adler32:cc943381
     ==> Verifying file demoanalyzer_cfg_level3data.py...
-      -> expected size 3689, found 3689
-      -> expected checksum adler32:1d3e2a43, found adler32:1d3e2a43
+      -> Expected size 3689, found 3689
+      -> Expected checksum adler32:1d3e2a43, found adler32:1d3e2a43
     ==> Verifying file demoanalyzer_cfg_level4MC.py...
-      -> expected size 3874, found 3874
-      -> expected checksum adler32:9cbd53a3, found adler32:9cbd53a3
+      -> Expected size 3874, found 3874
+      -> Expected checksum adler32:9cbd53a3, found adler32:9cbd53a3
     ==> Verifying file demoanalyzer_cfg_level4data.py...
-      -> expected size 3821, found 3821
-      -> expected checksum adler32:177b49c0, found adler32:177b49c0
+      -> Expected size 3821, found 3821
+      -> Expected checksum adler32:177b49c0, found adler32:177b49c0
     ==> Verifying file mass4l_combine.pdf...
-      -> expected size 18170, found 18170
-      -> expected checksum adler32:19c6a6a2, found adler32:19c6a6a2
+      -> Expected size 18170, found 18170
+      -> Expected checksum adler32:19c6a6a2, found adler32:19c6a6a2
     ==> Verifying file mass4l_combine.png...
-      -> expected size 93152, found 93152
-      -> expected checksum adler32:62e0c299, found adler32:62e0c299
+      -> Expected size 93152, found 93152
+      -> Expected checksum adler32:62e0c299, found adler32:62e0c299
     ==> Success!
 
 We can verify each file just after downloading with help of **download-files --verify** command.
@@ -374,24 +374,24 @@ We can verify each file just after downloading with help of **download-files --v
     $ cernopendata-client download-files --recid 5500 --filter-range 1-4 --verify
     ==> Downloading file 1 of 4
       -> File: ./5500/BuildFile.xml
-    ==> Verifying file BuildFile.xml... 
-      -> expected size 305, found 305
-      -> expected checksum adler32:ff63668a, found adler32:ff63668a
+    ==> Verifying file BuildFile.xml...
+      -> Expected size 305, found 305
+      -> Expected checksum adler32:ff63668a, found adler32:ff63668a
     ==> Downloading file 2 of 4
       -> File: ./5500/HiggsDemoAnalyzer.cc
-    ==> Verifying file HiggsDemoAnalyzer.cc... 
-      -> expected size 83761, found 83761
-      -> expected checksum adler32:f205f068, found adler32:f205f068
+    ==> Verifying file HiggsDemoAnalyzer.cc...
+      -> Expected size 83761, found 83761
+      -> Expected checksum adler32:f205f068, found adler32:f205f068
     ==> Downloading file 3 of 4
       -> File: ./5500/List_indexfile.txt
-    ==> Verifying file List_indexfile.txt... 
-      -> expected size 1669, found 1669
-      -> expected checksum adler32:46a907fc, found adler32:46a907fc
+    ==> Verifying file List_indexfile.txt...
+      -> Expected size 1669, found 1669
+      -> Expected checksum adler32:46a907fc, found adler32:46a907fc
     ==> Downloading file 4 of 4
       -> File: ./5500/M4Lnormdatall.cc
-    ==> Verifying file M4Lnormdatall.cc... 
-      -> expected size 14943, found 14943
-      -> expected checksum adler32:af301992, found adler32:af301992
+    ==> Verifying file M4Lnormdatall.cc...
+      -> Expected size 14943, found 14943
+      -> Expected checksum adler32:af301992, found adler32:af301992
     ==> Success!
 
 More information

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ tests_require = [
     'black>=19.10b0 ; python_version>="3"',
     "check-manifest>=0.25",
     "coverage>=4.0",
+    "mock>=3.0,<4.0",
     "pydocstyle>=1.0.0",
     "pytest-cache>=1.0",
     "pytest-cov>=1.8.0",


### PR DESCRIPTION
Simplifies usage of display_message() by keeping only one argument to
specify info/note/progress/error message types.

Tunes down the output colouring to resemble more faithfully the
practices from `yay` or `brew`, making the output more suitable for
various terminal colour schemes.

Pins `mock` dependency to version 3 so that Python-2.7 tests would
pass locally. (`tox -e py27`)