### PR TITLE
xrootd: from broken XRootDPyFS to vanilla XRootD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     lint-shellcheck:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         steps:
           - uses: actions/checkout@v2
 
@@ -18,7 +18,7 @@ jobs:
               ./run-tests.sh --check-shellscript
 
     lint-black:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         steps:
           - uses: actions/checkout@v2
 
@@ -33,7 +33,7 @@ jobs:
               ./run-tests.sh --check-black
 
     lint-pydocstyle:
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
       steps:
         - uses: actions/checkout@v2
 
@@ -48,7 +48,7 @@ jobs:
             ./run-tests.sh --check-pydocstyle
 
     lint-flake8:
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
       steps:
         - uses: actions/checkout@v2
 
@@ -63,7 +63,7 @@ jobs:
             ./run-tests.sh --check-flake8
 
     lint-check-manifest:
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
       steps:
         - uses: actions/checkout@v2
 
@@ -78,7 +78,7 @@ jobs:
             ./run-tests.sh --check-manifest
 
     lint-dockerfile:
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
       steps:
         - uses: actions/checkout@v2
 
@@ -86,7 +86,7 @@ jobs:
           run: ./run-tests.sh --check-dockerfile
 
     docs-sphinx:
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-20.04
       steps:
         - uses: actions/checkout@v2
 
@@ -98,8 +98,7 @@ jobs:
         - name: Install system dependencies
           run: |
             sudo apt-get update -y
-            sudo apt install libcurl4-openssl-dev libssl-dev
-            sudo apt-get install libgnutls28-dev
+            sudo apt-get install libcurl4-openssl-dev libgnutls28-dev libssl-dev uuid-dev
 
         - name: Install Python dependencies
           run: pip install -e .[docs]
@@ -108,7 +107,7 @@ jobs:
           run: ./run-tests.sh --check-sphinx
 
     python-tests:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         strategy:
           matrix:
               python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
@@ -124,14 +123,12 @@ jobs:
           - name: Install system dependencies
             run: |
               sudo apt-get update -y
-              sudo apt install libcurl4-openssl-dev libssl-dev uuid-dev
-              sudo apt-get install libgnutls28-dev
+              sudo apt-get install libcurl4-openssl-dev libgnutls28-dev libssl-dev uuid-dev
 
           - name: Install Python dependencies
             run: |
-              pip install "pip<20.3"
-              pip install wheel
-              pip install -e .[all]
+              pip install --upgrade pip setuptools wheel
+              pip install -e .[docs,tests,pycurl]
 
           - name: Run pytest
             run: ./run-tests.sh --check-pytest
@@ -143,10 +140,13 @@ jobs:
               token: ${{ secrets.CODECOV_TOKEN }}
               files: coverage.xml
 
-    docker-build:
-        runs-on: ubuntu-18.04
+    docker-tests:
+        runs-on: ubuntu-20.04
         steps:
           - uses: actions/checkout@v2
 
           - name: Build Docker image
             run: ./run-tests.sh --check-docker-build
+
+          - name: Run Docker image tests
+            run: sudo ./run-tests.sh --check-docker-run

--- a/cernopendata_client/cli.py
+++ b/cernopendata_client/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2019, 2020 CERN.
+# Copyright (C) 2019, 2020, 2021 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -246,10 +246,10 @@ def get_file_locations(server, recid, doi, title, protocol, expand, verbose):
 @click.option(
     "--download-engine",
     "download_engine",
-    type=click.Choice(["requests", "pycurl", "xrootdpyfs"]),
+    type=click.Choice(["requests", "pycurl", "xrootd"]),
     help="Download engine to use when downloading files."
-    "The available values are 'requests', 'pycurl', 'xrootdpyfs'."
-    "[default=requests (for HTTP protocol), xrootdpyfs (for XRootD protocol)]",
+    "The available values are 'requests', 'pycurl', 'xrootd'."
+    "[default=requests (for HTTP protocol), xrootd (for XRootD protocol)]",
 )
 def download_files(
     server,
@@ -343,7 +343,7 @@ def download_files(
         if protocol.startswith("http"):
             download_engine = "requests"
         elif protocol == "xrootd":
-            download_engine = "xrootdpyfs"
+            download_engine = "xrootd"
     for file_location in download_file_locations:
         display_message(
             msg_type="info",

--- a/cernopendata_client/config.py
+++ b/cernopendata_client/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2021 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -40,7 +40,7 @@ DOWNLOAD_ERROR_PAGE = {"size": 3846, "checksum": "adler32:a82d5324"}
 """Error page info from the server."""
 
 DOWNLOAD_ENGINE_PROTOCOL_HTTP_MAP = ["pycurl", "requests"]
-"""Download engine compatible with HTTP protocol."""
+"""Download engines compatible with HTTP protocol."""
 
-DOWNLOAD_ENGINE_PROTOCOL_XROOTD_MAP = ["xrootdpyfs"]
-"""Download engine compatible with xrootd protocol."""
+DOWNLOAD_ENGINE_PROTOCOL_XROOTD_MAP = ["xrootd"]
+"""Download engines compatible with xrootd protocol."""

--- a/cernopendata_client/walker.py
+++ b/cernopendata_client/walker.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2021 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -10,6 +10,7 @@
 
 from __future__ import print_function
 
+import os
 import sys
 import datetime
 
@@ -17,54 +18,26 @@ from .config import SERVER_ROOT_URI
 from .printer import display_message
 
 try:
-    from xrootdpyfs import XRootDPyFS
+    from XRootD import client as xrootdclient
+    from XRootD.client.flags import DirListFlags
 
+    FS = xrootdclient.FileSystem(SERVER_ROOT_URI)
     xrootd_available = True
 except ImportError:
     xrootd_available = False
 
 
-def get_list_directory_recursive(path, timeout):
-    """Return list of contents of a EOSPUBLIC Open Data directory recursively.
-
-    :param path: EOSPUBLIC path
-    :type path: str
-
-    :return: List of files
-    :rtype: list
-    """
-    files_list = []
-    timeout_flag = False
-    start_time = datetime.datetime.now()
-    fs = XRootDPyFS("root://eospublic.cern.ch//")
-    try:
-        for dirs, files in fs.walk(path):
-            current_time = datetime.datetime.now()
-            elapsed_time = current_time - start_time
-            if elapsed_time.seconds > timeout:
-                timeout_flag = True
-                break
-            else:
-                for _file in files:
-                    files_list.append(dirs + "/" + _file)
-        return files_list, timeout_flag
-    except Exception:
-        display_message(
-            msg_type="error",
-            msg="Directory {} does not exist.".format(path),
-        )
-        sys.exit(1)
-
-
-def get_list_directory(path, recursive, timeout):
+def get_list_directory(path, recursive, timeout, time_start=None):
     """Return list of contents of a EOSPUBLIC Open Data directory.
 
     :param path: EOSPUBLIC path
-    :param recursive: Iterate recurcively in the given directory path.
+    :param recursive: Iterate recursively into subdirectories?
     :param timeout: Timeout for list-directory command.
+    :param time_start: Optionally, time When the recursive search started.
     :type path: str
     :type recursive: bool
     :type timeout: int
+    :type time_start: datetime
 
     :return: List of files
     :rtype: list
@@ -75,25 +48,33 @@ def get_list_directory(path, recursive, timeout):
             msg="xrootd is required for this operation but it is not installed on your system.",
         )
         sys.exit(1)
-    if not recursive:
-        directory = SERVER_ROOT_URI + path
-        fs = XRootDPyFS(directory)
-        try:
-            files_list = fs.listdir()
-            files_list = [path + file_ for file_ in files_list]
-            return files_list
-        except Exception:
-            display_message(
-                msg_type="error",
-                msg="Directory {} does not exist.".format(path),
-            )
-            sys.exit(1)
-    else:
-        files_list, timeout_flag = get_list_directory_recursive(path, timeout)
-        if timeout_flag:
-            display_message(
-                msg_type="error",
-                msg="Command timed out. Please provide more specific path.",
-            )
-            sys.exit(2)
-        return files_list
+    if not time_start:
+        time_start = datetime.datetime.now()
+    if (datetime.datetime.now() - time_start).seconds > timeout:
+        display_message(
+            msg_type="error",
+            msg="Command timed out. Please increase timeout or provide more specific path.",
+        )
+        sys.exit(2)
+    files = []
+    try:
+        status, listing = FS.dirlist(path, DirListFlags.STAT)
+        for entry in listing:
+            if entry.statinfo.flags == 19:  # entry is a directory
+                files.append(path + os.sep + entry.name)
+                if recursive:
+                    files.extend(
+                        get_list_directory(
+                            path + os.sep + entry.name, recursive, timeout, time_start
+                        )
+                    )
+            else:
+                files.append(path + os.sep + entry.name)
+        return files
+    except Exception:
+        display_message(
+            msg_type="error",
+            msg="Directory {} does not exist.".format(path),
+        )
+        sys.exit(1)
+    return files

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,8 +23,8 @@ import sphinx.environment
 # -- Project information -----------------------------------------------------
 
 project = "cernopendata_client"
-copyright = "2019, CERN"
-author = "CERN Analysis Preservation"
+copyright = "2019-2021, CERN"
+author = "CERN Open Data"
 
 # Get the version string. Cannot be done with import!
 g = {}
@@ -56,7 +56,7 @@ extensions = [
 ]
 
 # Autodoc mocking to fix ReadTheDocs builds missing system dependencies
-autodoc_mock_imports = ["pycurl", "xrootdpyfs"]
+autodoc_mock_imports = ["pycurl", "xrootd"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,20 +56,20 @@ In order to get metadata information about a record, please use the
 
     $ cernopendata-client get-metadata --recid 1
     {
-	"$schema": "http://opendata.cern.ch/schema/records/record-v1.0.0.json",
-	"abstract": {
-	    "description": "<p>BTau primary dataset in AOD format from RunB of 2010</p> <p>This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</p>",
-	    "links": [
-		{
-		    "recid": "1000"
-		}
-	    ]
-	},
-	"accelerator": "CERN-LHC",
-	"collaboration": {
-	    "name": "CMS collaboration",
-	    "recid": "450"
-	},
+        "$schema": "http://opendata.cern.ch/schema/records/record-v1.0.0.json",
+        "abstract": {
+            "description": "<p>BTau primary dataset in AOD format from RunB of 2010</p> <p>This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</p>",
+            "links": [
+                {
+                    "recid": "1000"
+                }
+            ]
+        },
+        "accelerator": "CERN-LHC",
+        "collaboration": {
+            "name": "CMS collaboration",
+            "recid": "450"
+        },
     ...
 
 This will output a JSON containing all the record metadata, such as
@@ -249,10 +249,10 @@ xrootd`` command-line option to use that protocol instead of HTTP/HTTPS:
 
 **Select download engine**
 
-You can specify the download engine with ``--download-engine`` option. 
+You can specify the download engine with ``--download-engine`` option.
 
 - ``requests`` and ``pycurl`` are two supported download engines for **HTTP** protocol.
-- ``xrootdpyfs`` is the only supported download engine for **XRootD** protocol.
+- ``xrootd`` is the only supported download engine for **XRootD** protocol.
 
 .. code-block:: console
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2019, 2020 CERN.
+# Copyright (C) 2019, 2020, 2021 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -39,7 +39,10 @@ check_dockerfile () {
 
 check_docker_build () {
     docker build -t cernopendata/cernopendata-client .
-    docker run --rm cernopendata/cernopendata-client version
+}
+
+check_docker_run () {
+    docker run --rm -v "$PWD"/tests:/code/tests --entrypoint /bin/bash cernopendata/cernopendata-client -c 'pytest tests'
 }
 
 check_sphinx () {
@@ -59,6 +62,7 @@ if [ $# -eq 0 ]; then
     check_manifest
     check_dockerfile
     check_docker_build
+    check_docker_run
     check_sphinx
     check_pytest
 fi
@@ -73,6 +77,7 @@ do
         --check-manifest) check_manifest;;
         --check-dockerfile) check_dockerfile;;
         --check-docker-build) check_docker_build;;
+        --check-docker-run) check_docker_run;;
         --check-sphinx) check_sphinx;;
         --check-pytest) check_pytest;;
         *)

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,7 @@ extras_require = {
     ],
     "tests": tests_require,
     "xrootd": [
-        "xrootd<=4.12.2",
-        "xrootdpyfs>=0.2",
+        "xrootd>=4.12.2",
     ],
     "pycurl": ["pycurl>=7"],
 }

--- a/tests/test_cli_download_files.py
+++ b/tests/test_cli_download_files.py
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2021 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -143,7 +143,7 @@ def test_download_files_download_engine(mocker):
 
 def test_download_files_download_engine_wrong_protocol_combination_one():
     """Test download_files() command with download-engine option and wrong protocol."""
-    xrootdpyfs = pytest.importorskip("xrootdpyfs")  # noqa: F841
+    xrootd = pytest.importorskip("XRootD")  # noqa: F841
     test_download_files = CliRunner()
     test_result = test_download_files.invoke(
         download_files,
@@ -155,19 +155,19 @@ def test_download_files_download_engine_wrong_protocol_combination_one():
 
 def test_download_files_download_engine_wrong_protocol_combination_two():
     """Test download_files() command with download-engine option and wrong protocol."""
-    xrootdpyfs = pytest.importorskip("xrootdpyfs")  # noqa: F841
+    xrootd = pytest.importorskip("XRootD")  # noqa: F841
     test_download_files = CliRunner()
     test_result = test_download_files.invoke(
         download_files,
-        ["--recid", 3005, "--download-engine", "xrootdpyfs", "--protocol", "http"],
+        ["--recid", 3005, "--download-engine", "xrootd", "--protocol", "http"],
     )
     assert test_result.exit_code == 1
-    assert "xrootdpyfs is not compatible with http" in test_result.output
+    assert "xrootd is not compatible with http" in test_result.output
 
 
 def test_download_files_root():
     """Test download_files() command with xrootd protocol."""
-    xrootdpyfs = pytest.importorskip("xrootdpyfs")  # noqa: F841
+    xrootd = pytest.importorskip("XRootD")  # noqa: F841
     test_file = "3005/0d0714743f0204ed3c0144941e6ce248.configFile.py"
     if os.path.isfile(test_file):
         os.remove(test_file)
@@ -191,7 +191,7 @@ def test_download_files_root_wrong(mocker):
         download_files, ["--recid", 3005, "--protocol", "xrootd"]
     )
     assert test_result.exit_code == 1
-    assert "xrootdpyfs is not installed on system" in test_result.output
+    assert "xrootd is not installed on system" in test_result.output
 
 
 def test_download_files_with_verify():

--- a/tests/test_cli_list_directory.py
+++ b/tests/test_cli_list_directory.py
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2021 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -17,7 +17,7 @@ from cernopendata_client.cli import list_directory
 
 def test_non_recursive_list_directory():
     """Test `list_directory` command."""
-    xrootdpyfs = pytest.importorskip("xrootdpyfs")  # noqa: F841
+    xrootd = pytest.importorskip("XRootD")  # noqa: F841
     test_non_recursive = CliRunner()
     test_result = test_non_recursive.invoke(
         list_directory, ["/eos/opendata/cms/validated-runs/Commissioning10"]
@@ -28,7 +28,7 @@ def test_non_recursive_list_directory():
 
 def test_recursive_list_directory():
     """Test `list_directory --recursive` command."""
-    xrootdpyfs = pytest.importorskip("xrootdpyfs")  # noqa: F841
+    xrootd = pytest.importorskip("XRootD")  # noqa: F841
     test_recursive = CliRunner()
     test_result = test_recursive.invoke(
         list_directory, ["/eos/opendata/cms/Run2010B/BTau/AOD", "--recursive"]
@@ -38,7 +38,7 @@ def test_recursive_list_directory():
 
 def test_recursive_list_directory_timeout():
     """Test `list_directory --recursive` command with timeout."""
-    xrootdpyfs = pytest.importorskip("xrootdpyfs")  # noqa: F841
+    xrootd = pytest.importorskip("XRootD")  # noqa: F841
     test_recursive = CliRunner()
     test_result = test_recursive.invoke(
         list_directory, ["/eos/opendata/cms", "--recursive", "--timeout", 5]
@@ -49,7 +49,7 @@ def test_recursive_list_directory_timeout():
 
 def test_non_recursive_list_directory_wrong():
     """Test `list_directory` command with wrong path"""
-    xrootdpyfs = pytest.importorskip("xrootdpyfs")  # noqa: F841
+    xrootd = pytest.importorskip("XRootD")  # noqa: F841
     test_non_recursive = CliRunner()
     test_result = test_non_recursive.invoke(list_directory, ["/eos/opendata/foobar"])
     assert test_result.exit_code == 1
@@ -58,7 +58,7 @@ def test_non_recursive_list_directory_wrong():
 
 def test_recursive_list_directory_wrong():
     """Test `list_directory --recursive` command with wrong path."""
-    xrootdpyfs = pytest.importorskip("xrootdpyfs")  # noqa: F841
+    xrootd = pytest.importorskip("XRootD")  # noqa: F841
     test_recursive = CliRunner()
     test_result = test_recursive.invoke(
         list_directory, ["/eos/opendata/recursiveFoobar", "--recursive"]

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2021 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -25,14 +25,14 @@ from cernopendata_client.verifier import (
 
 def test_get_file_size():
     """Test get_file_size()."""
-    afile = "./LICENSE"
-    assert get_file_size(afile) == 35149
+    afile = "./tests/test_version.py"
+    assert get_file_size(afile) == 641
 
 
 def test_get_file_checksum():
     """Test get_file_checksum()."""
-    afile = "./LICENSE"
-    assert get_file_checksum(afile) == "adler32:f70779ec"
+    afile = "./tests/test_version.py"
+    assert get_file_checksum(afile) == "adler32:fa91da1e"
 
 
 def test_get_file_info_local_wrong_input():


### PR DESCRIPTION
Changes all XRootD operations such as `download-files` and
`list-directory` to use (vanilla) XRootD Python library instead of
(broken) XRootDPyFS. Closes #119.