### PR TITLE
docker: optimise image and change base Fedora 38

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@ Version 0.4.0 (UNRELEASED)
 --------------------------
 
 - Adds support for Python 3.11 and 3.12.
-- Drops support for Python 2.7.
 - Improves ``get-metadata --output-field`` command by adding a new ``--filter`` option allowing to output only selected field values matching desired criteria.
+- Changes container image base to Fedora 38 and slightly optimises image size.
+- Drops support for Python 2.7.
 
 Version 0.3.0 (2022-03-16)
 --------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,42 @@
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020, 2022 CERN.
+# Copyright (C) 2020, 2022, 2023 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
 
-# Use Fedora 35
-FROM fedora:35
+# Use Fedora 38
+FROM registry.fedoraproject.org/fedora:38
 
-# Install system prerequisites
-# hadolint ignore=DL3033
-RUN yum install -y \
-        ca-certificates && \
-    yum install -y \
-        cmake \
+# Install prerequisites
+# hadolint ignore=DL3033,DL3041
+RUN dnf install -y \
+        black \
+        ca-certificates \
+        check-manifest \
         curl \
-        gcc \
-        gcc-c++ \
-        libcurl-devel \
-        libuuid-devel \
-        make \
-        openssl-devel \
-        python3-devel \
+        python3-certifi \
+        python3-click \
+        python3-coverage \
+        python3-docutils \
+        python3-jinja2 \
+        python3-mock \
+        python3-pbr \
         python3-pip \
+        python3-pycurl \
+        python3-pydocstyle \
+        python3-pytest \
+        python3-pytest-cache \
+        python3-pytest-cov \
+        python3-pytest-mock \
+        python3-requests \
+        python3-urllib3 \
         python3-wheel \
-        xrootd-client \
-        zlib-devel && \
-    yum autoremove && \
-    yum clean all
+        python3-xrootd \
+        xrootd-client && \
+    dnf autoremove -y && \
+    dnf clean all && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add sources to `/code` and work there
 WORKDIR /code
@@ -35,11 +44,8 @@ COPY . /code
 
 # Install cernopendata-client
 # hadolint ignore=DL3013
-RUN pip3 install --no-cache-dir '.[all]'
-
-# Remove /code to make image slimmer
-# hadolint ignore=DL3059
-RUN rm -rf /code
+RUN pip3 install --no-cache-dir '.[pycurl,tests,xrootd]' && \
+    rm -rf /code
 
 # Run container as `cernopendata` user with UID `1000`, which should match
 # current host user in most situations

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,6 +55,6 @@ image contains both `pycurl` and `xrootd` flavours:
 
 .. code-block:: console
 
-   $ docker pull cernopendata/cernopendata-client
-   $ docker run -i -t --rm cernopendata/cernopendata-client --help
+   $ docker pull docker.io/cernopendata/cernopendata-client
+   $ docker run -i -t --rm docker.io/cernopendata/cernopendata-client --help
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2019, 2020, 2021 CERN.
+# Copyright (C) 2019, 2020, 2021, 2023 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -34,15 +34,15 @@ check_manifest () {
 }
 
 check_dockerfile () {
-    docker run -i --rm hadolint/hadolint < Dockerfile
+    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 < Dockerfile
 }
 
 check_docker_build () {
-    docker build -t cernopendata/cernopendata-client .
+    docker build -t docker.io/cernopendata/cernopendata-client .
 }
 
 check_docker_run () {
-    docker run --rm -v "$PWD"/tests:/code/tests --entrypoint /bin/bash cernopendata/cernopendata-client -c 'pytest tests'
+    docker run --rm -v "$PWD"/tests:/code/tests --entrypoint /bin/bash docker.io/cernopendata/cernopendata-client -c 'pytest tests'
 }
 
 check_sphinx () {

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ tests_require = [
     'black>=19.10b0 ; python_version>="3"',
     "check-manifest>=0.25",
     "coverage>=4.0",
-    "mock>=3.0,<4.0",
+    "mock>=3.0",
     "pydocstyle>=1.0.0",
     "pytest-cache>=1.0",
     "pytest-cov>=1.8.0",
@@ -33,15 +33,15 @@ tests_require = [
 extras_require = {
     "docs": [
         "jinja2<3.1.0",
-        "Sphinx>=1.4.4,<2.0",
+        "Sphinx>=1.4.4",
         "sphinx-rtd-theme>=0.1.9",
         "sphinx-click>=2.5.0",
     ],
+    "pycurl": ["pycurl>=7"],
     "tests": tests_require,
     "xrootd": [
         "xrootd>=4.12.2",
     ],
-    "pycurl": ["pycurl>=7"],
 }
 
 extras_require["all"] = []


### PR DESCRIPTION
Upgrades the base container image to Fedora 38 and optimises the container image building process by pre-installing system Python packages. This helps (i) time-wise, because lengthy XRootD package installation during `pip` is no longer necessary; (ii) space-wise, because several unnecessary compilation-time dependencies are not installed anymore. The size of the produced container image is reduced to one half.