### PR TITLE
fix(searcher): respect `get-file-locations --server` parameter (#155)

### DIFF
--- a/cernopendata_client/searcher.py
+++ b/cernopendata_client/searcher.py
@@ -198,10 +198,8 @@ def get_files_list(
     files_list = []
 
     new_server = SERVER_ROOT_URI
-    if searcher_protocol == "http":
+    if searcher_protocol in ("http", "https"):
         new_server = server
-    elif searcher_protocol == "https":
-        new_server = SERVER_HTTPS_URI
 
     for file_ in record_json["metadata"].get("files", []):
         files_list.append(
@@ -262,7 +260,7 @@ def get_file_info_remote(server, recid, protocol=None, filtered_files=None):
         if searcher_protocol == "http":
             file_uri = file_info["uri"].replace(SERVER_ROOT_URI, server)
         elif searcher_protocol == "https":
-            file_uri = file_info["uri"].replace(SERVER_ROOT_URI, SERVER_HTTPS_URI)
+            file_uri = file_info["uri"].replace(SERVER_ROOT_URI, server)
         if not filtered_files or file_uri in filtered_files:
             file_info_remote.append(
                 {

--- a/tests/test_cli_get_file_locations.py
+++ b/tests/test_cli_get_file_locations.py
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2025 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -130,3 +130,15 @@ def test_get_file_locations_no_expand_with_http_protocol():
     assert test_result.exit_code == 0
     assert "http://opendata.cern.ch" in test_result.output
     assert "file_index" in test_result.output
+
+
+def test_get_file_locations_with_custom_https_server():
+    """Test `get-file-locations --server` command for custom https server."""
+    test_get_file_locations = CliRunner()
+    test_result = test_get_file_locations.invoke(
+        get_file_locations, ["--recid", 3005, "--server", "https://opendata-qa.cern.ch"]
+    )
+    assert test_result.exit_code == 0
+    assert "https://opendata-qa.cern.ch" in test_result.output
+    assert "https://opendata.cern.ch" not in test_result.output
+    assert "configFile.py" in test_result.output


### PR DESCRIPTION
Fixes issue where `get-file-locations --server https://example.org` would ignore the custom server and revert to the default HTTPS server.

Closes #153