### PR TITLE
fix(verifier): zero-pad Adler32 checksums to 8 hex characters (#169)

### DIFF
--- a/cernopendata_client/verifier.py
+++ b/cernopendata_client/verifier.py
@@ -38,7 +38,9 @@ def get_file_checksum(afile):
     :return: Adler32 checksum of file
     :rtype: str
     """
-    return "adler32:" + hex(zlib.adler32(open(afile, "rb").read(), 1) & 0xFFFFFFFF)[2:]
+    return "adler32:{:08x}".format(
+        zlib.adler32(open(afile, "rb").read(), 1) & 0xFFFFFFFF
+    )
 
 
 def get_file_info_local(recid):


### PR DESCRIPTION
The hex() function does not preserve leading zeros, causing checksum verification to fail when the expected checksum value sent by the CERN Open Data portal has a leading zero (e.g. "03d9681c" vs computed "3d9681c"). This commit fixes the problem.