### PR TITLE
test(global): add @pytest.mark.local marker for local-only tests (#170)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,30 +30,49 @@ The project uses `run-tests.sh` for all quality checks. Run all checks with:
 
 ### Individual Check Commands
 
-| Command                              | Description                            |
-| ------------------------------------ | -------------------------------------- |
-| `./run-tests.sh --python-tests`      | Run pytest test suite                  |
-| `./run-tests.sh --format-black`      | Check Python formatting (black)        |
-| `./run-tests.sh --lint-flake8`       | Lint Python code (flake8)              |
-| `./run-tests.sh --lint-pydocstyle`   | Check Python docstrings                |
-| `./run-tests.sh --format-prettier`   | Check Markdown/YAML formatting         |
-| `./run-tests.sh --format-shfmt`      | Check shell script formatting          |
-| `./run-tests.sh --lint-shellcheck`   | Lint shell scripts                     |
-| `./run-tests.sh --lint-markdownlint` | Lint Markdown files                    |
-| `./run-tests.sh --lint-yamllint`     | Lint YAML files                        |
-| `./run-tests.sh --lint-jsonlint`     | Lint JSON files                        |
-| `./run-tests.sh --lint-commitlint`   | Check commit message format            |
-| `./run-tests.sh --lint-manifest`     | Check Python manifest (check-manifest) |
-| `./run-tests.sh --docs-sphinx`       | Build and test Sphinx documentation    |
-| `./run-tests.sh --docker-build`      | Build Docker image                     |
-| `./run-tests.sh --docker-tests`      | Run tests in Docker container          |
-| `./run-tests.sh --lint-hadolint`     | Lint Dockerfile                        |
+| Command                               | Description                            |
+| ------------------------------------- | -------------------------------------- |
+| `./run-tests.sh --python-tests`       | Run pytest test suite (all tests)      |
+| `./run-tests.sh --python-tests-local` | Run pytest test suite (local only)     |
+| `./run-tests.sh --format-black`       | Check Python formatting (black)        |
+| `./run-tests.sh --lint-flake8`        | Lint Python code (flake8)              |
+| `./run-tests.sh --lint-pydocstyle`    | Check Python docstrings                |
+| `./run-tests.sh --format-prettier`    | Check Markdown/YAML formatting         |
+| `./run-tests.sh --format-shfmt`       | Check shell script formatting          |
+| `./run-tests.sh --lint-shellcheck`    | Lint shell scripts                     |
+| `./run-tests.sh --lint-markdownlint`  | Lint Markdown files                    |
+| `./run-tests.sh --lint-yamllint`      | Lint YAML files                        |
+| `./run-tests.sh --lint-jsonlint`      | Lint JSON files                        |
+| `./run-tests.sh --lint-commitlint`    | Check commit message format            |
+| `./run-tests.sh --lint-manifest`      | Check Python manifest (check-manifest) |
+| `./run-tests.sh --docs-sphinx`        | Build and test Sphinx documentation    |
+| `./run-tests.sh --docker-build`       | Build Docker image                     |
+| `./run-tests.sh --docker-tests`       | Run tests in Docker container          |
+| `./run-tests.sh --lint-hadolint`      | Lint Dockerfile                        |
 
 ### Using tox for Multi-Python Testing
 
 ```bash
 tox           # Run tests across all Python versions (3.8-3.14)
 tox -e py312  # Run tests for specific Python version
+```
+
+### Local vs Remote Tests
+
+Tests that run locally without network access are marked with
+`@pytest.mark.local`. Use pytest markers or run-tests.sh to run subsets:
+
+```bash
+# Run only local tests (no network access)
+./run-tests.sh --python-tests-local
+pytest -m local
+
+# Run only remote tests (connect to CERN Open Data portal)
+pytest -m "not local"
+
+# Run all tests
+./run-tests.sh --python-tests
+pytest
 ```
 
 ## Project Structure

--- a/cernopendata_client/searcher.py
+++ b/cernopendata_client/searcher.py
@@ -13,14 +13,10 @@ from __future__ import print_function
 import sys
 import requests
 
+from urllib.parse import quote
+
 from .config import SERVER_HTTP_URI, SERVER_ROOT_URI, SERVER_HTTPS_URI
 from .printer import display_message
-
-try:
-    from urllib.parse import quote
-except ImportError:
-    # fallback for Python 2
-    from urllib import quote
 
 
 def verify_recid(server=None, recid=None):

--- a/cernopendata_client/validator.py
+++ b/cernopendata_client/validator.py
@@ -117,9 +117,6 @@ def validate_directory(directory=None):
     :return: Bool after verifying directory
     :rtype: bool
     """
-    if sys.version_info[0] < 3:
-        if isinstance(directory, unicode):  # noqa F821
-            directory = directory.encode("utf-8")
     if isinstance(directory, str):
         if not directory.startswith("/eos/opendata/"):
             display_message(

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,5 @@
 
 [pytest]
 addopts = --ignore=docs --cov=cernopendata_client --cov-report=xml --cov-report=term-missing
+markers =
+    local: marks tests that run locally without network access (select with '-m local')

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -97,6 +97,10 @@ python_tests() {
     pytest
 }
 
+python_tests_local() {
+    pytest -m local
+}
+
 format_shfmt() {
     shfmt -d .
 }
@@ -145,6 +149,7 @@ help() {
     echo "  --lint-shellcheck    Check linting of shell scripts"
     echo "  --lint-yamllint      Check linting of YAML files"
     echo "  --python-tests       Check Python test suite"
+    echo "  --python-tests-local Check Python test suite (local tests only, no portal access)"
 }
 
 if [ $# -eq 0 ]; then
@@ -172,5 +177,6 @@ case $arg in
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 --python-tests) python_tests ;;
+--python-tests-local) python_tests_local ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/tests/test_cli_download_files.py
+++ b/tests/test_cli_download_files.py
@@ -236,6 +236,7 @@ def test_download_files_with_verify():
         os.remove(test_file)
 
 
+@pytest.mark.local
 def test_download_files_empty_value():
     """Test download_files() command with empty value."""
     test_download_files_empty_value = CliRunner()
@@ -244,6 +245,7 @@ def test_download_files_empty_value():
     assert "Please provide at least one of following arguments" in test_result.output
 
 
+@pytest.mark.local
 def test_download_files_wrong_value():
     """Test download_files() command with wrong value."""
     test_download_files_empty_value = CliRunner()

--- a/tests/test_cli_get_file_locations.py
+++ b/tests/test_cli_get_file_locations.py
@@ -9,6 +9,8 @@
 
 """cernopendata-client cli command get-file-locations test."""
 
+import pytest
+
 from click.testing import CliRunner
 from cernopendata_client.cli import get_file_locations
 from cernopendata_client.config import SERVER_HTTPS_URI, SERVER_ROOT_URI

--- a/tests/test_cli_get_metadata.py
+++ b/tests/test_cli_get_metadata.py
@@ -9,6 +9,8 @@
 
 """cernopendata-client cli command get-metadata test."""
 
+import pytest
+
 from click.testing import CliRunner
 from cernopendata_client.cli import get_metadata
 
@@ -97,6 +99,7 @@ def test_get_metadata_from_output_fields_wrong():
     assert "Field 'global_tag' is not present in metadata\n" in test_result.output
 
 
+@pytest.mark.local
 def test_get_metadata_empty_value():
     """Test get_metadata() command with empty value."""
     test_get_metadata_empty_value = CliRunner()
@@ -105,6 +108,7 @@ def test_get_metadata_empty_value():
     assert "Please provide at least one of following arguments" in test_result.output
 
 
+@pytest.mark.local
 def test_get_metadata_wrong_value():
     """Test download_files() command with wrong value."""
     test_get_metadata_wrong_value = CliRunner()

--- a/tests/test_cli_get_metadata.py
+++ b/tests/test_cli_get_metadata.py
@@ -118,3 +118,13 @@ def test_get_metadata_wrong_value():
     )
     assert test_result.exit_code == 2
     assert "Invalid value for --server" in test_result.output
+
+
+def test_get_metadata_filter_without_output_value():
+    """Test get-metadata --filter without --output-value."""
+    test_get_metadata = CliRunner()
+    test_result = test_get_metadata.invoke(
+        get_metadata, ["--recid", 1, "--filter", "foo=bar"]
+    )
+    assert test_result.exit_code == 0
+    assert "--filter can only be used with --output-value" in test_result.output

--- a/tests/test_cli_list_directory.py
+++ b/tests/test_cli_list_directory.py
@@ -66,3 +66,13 @@ def test_recursive_list_directory_wrong():
     assert (
         "Directory /eos/opendata/recursiveFoobar does not exist." in test_result.output
     )
+
+
+@pytest.mark.local
+def test_list_directory_empty(mocker):
+    """Test `list_directory` command with empty directory."""
+    mocker.patch("cernopendata_client.cli.get_list_directory", return_value=[])
+    test_empty = CliRunner()
+    test_result = test_empty.invoke(list_directory, ["/eos/opendata/test"])
+    assert test_result.exit_code == 2
+    assert "No files in the directory" in test_result.output

--- a/tests/test_cli_verify_files.py
+++ b/tests/test_cli_verify_files.py
@@ -74,6 +74,7 @@ def test_verify_files_https_server():
         os.remove(test_file)
 
 
+@pytest.mark.local
 def test_verify_files_empty_value():
     """Test verify-files command with empty value."""
     test_verify_files_empty_value = CliRunner()
@@ -82,6 +83,7 @@ def test_verify_files_empty_value():
     assert "Please provide at least one of following arguments" in test_result.output
 
 
+@pytest.mark.local
 def test_verify_files_wrong_value():
     """Test verify-files command with wrong value."""
     test_verify_files_wrong_value = CliRunner()

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of cernopendata-client.
+#
+# Copyright (C) 2025 CERN.
+#
+# cernopendata-client is free software; you can redistribute it and/or modify
+# it under the terms of the GPLv3 license; see LICENSE file for more details.
+
+"""cernopendata-client downloader unit tests."""
+
+import pytest
+
+from cernopendata_client.downloader import (
+    get_download_files_by_name,
+    get_download_files_by_regexp,
+    get_download_files_by_range,
+)
+
+
+@pytest.mark.local
+def test_get_download_files_by_name_single():
+    """Test filtering files by a single name."""
+    file_locations = [
+        "http://example.com/a.txt",
+        "http://example.com/b.txt",
+        "http://example.com/c.py",
+    ]
+    result = get_download_files_by_name(names=["a.txt"], file_locations=file_locations)
+    assert result == ["http://example.com/a.txt"]
+
+
+@pytest.mark.local
+def test_get_download_files_by_name_multiple():
+    """Test filtering files by multiple names."""
+    file_locations = [
+        "http://example.com/a.txt",
+        "http://example.com/b.txt",
+        "http://example.com/c.py",
+    ]
+    result = get_download_files_by_name(
+        names=["a.txt", "c.py"], file_locations=file_locations
+    )
+    assert result == ["http://example.com/a.txt", "http://example.com/c.py"]
+
+
+@pytest.mark.local
+def test_get_download_files_by_name_no_match():
+    """Test filtering files by name with no matches."""
+    file_locations = [
+        "http://example.com/a.txt",
+        "http://example.com/b.txt",
+    ]
+    result = get_download_files_by_name(
+        names=["nonexistent.txt"], file_locations=file_locations
+    )
+    assert result == []
+
+
+@pytest.mark.local
+def test_get_download_files_by_regexp_extension():
+    """Test filtering files by regexp matching extension."""
+    file_locations = [
+        "http://example.com/a.py",
+        "http://example.com/b.txt",
+        "http://example.com/c.py",
+    ]
+    result = get_download_files_by_regexp(
+        regexp=r"\.py$", file_locations=file_locations
+    )
+    assert result == ["http://example.com/a.py", "http://example.com/c.py"]
+
+
+@pytest.mark.local
+def test_get_download_files_by_regexp_pattern():
+    """Test filtering files by regexp pattern."""
+    file_locations = [
+        "http://example.com/test_001.dat",
+        "http://example.com/test_002.dat",
+        "http://example.com/other.dat",
+    ]
+    result = get_download_files_by_regexp(
+        regexp=r"test_\d+", file_locations=file_locations
+    )
+    assert result == [
+        "http://example.com/test_001.dat",
+        "http://example.com/test_002.dat",
+    ]
+
+
+@pytest.mark.local
+def test_get_download_files_by_regexp_with_filtered_files():
+    """Test filtering files by regexp with pre-filtered files."""
+    file_locations = [
+        "http://example.com/a.py",
+        "http://example.com/b.py",
+        "http://example.com/c.txt",
+    ]
+    filtered_files = ["http://example.com/a.py", "http://example.com/c.txt"]
+    result = get_download_files_by_regexp(
+        regexp=r"\.py$", file_locations=file_locations, filtered_files=filtered_files
+    )
+    assert result == ["http://example.com/a.py"]
+
+
+@pytest.mark.local
+def test_get_download_files_by_regexp_no_match():
+    """Test filtering files by regexp with no matches."""
+    file_locations = [
+        "http://example.com/a.txt",
+        "http://example.com/b.txt",
+    ]
+    result = get_download_files_by_regexp(
+        regexp=r"\.py$", file_locations=file_locations
+    )
+    assert result == []
+
+
+@pytest.mark.local
+def test_get_download_files_by_range_single():
+    """Test filtering files by a single range."""
+    file_locations = [
+        "http://example.com/file1.txt",
+        "http://example.com/file2.txt",
+        "http://example.com/file3.txt",
+        "http://example.com/file4.txt",
+        "http://example.com/file5.txt",
+    ]
+    result = get_download_files_by_range(ranges=["2-4"], file_locations=file_locations)
+    assert result == [
+        "http://example.com/file2.txt",
+        "http://example.com/file3.txt",
+        "http://example.com/file4.txt",
+    ]
+
+
+@pytest.mark.local
+def test_get_download_files_by_range_multiple():
+    """Test filtering files by multiple ranges."""
+    file_locations = [
+        "http://example.com/file1.txt",
+        "http://example.com/file2.txt",
+        "http://example.com/file3.txt",
+        "http://example.com/file4.txt",
+        "http://example.com/file5.txt",
+    ]
+    result = get_download_files_by_range(
+        ranges=["1-2", "4-5"], file_locations=file_locations
+    )
+    assert result == [
+        "http://example.com/file1.txt",
+        "http://example.com/file2.txt",
+        "http://example.com/file4.txt",
+        "http://example.com/file5.txt",
+    ]
+
+
+@pytest.mark.local
+def test_get_download_files_by_range_single_file():
+    """Test filtering files by range selecting a single file."""
+    file_locations = [
+        "http://example.com/file1.txt",
+        "http://example.com/file2.txt",
+        "http://example.com/file3.txt",
+    ]
+    result = get_download_files_by_range(ranges=["2-2"], file_locations=file_locations)
+    assert result == ["http://example.com/file2.txt"]
+
+
+@pytest.mark.local
+def test_get_download_files_by_range_with_filtered_files():
+    """Test filtering files by range with pre-filtered files."""
+    file_locations = [
+        "http://example.com/file1.txt",
+        "http://example.com/file2.txt",
+        "http://example.com/file3.txt",
+    ]
+    filtered_files = ["http://example.com/file1.txt", "http://example.com/file3.txt"]
+    result = get_download_files_by_range(
+        ranges=["1-2"], file_locations=file_locations, filtered_files=filtered_files
+    )
+    assert result == ["http://example.com/file1.txt", "http://example.com/file3.txt"]

--- a/tests/test_metadater.py
+++ b/tests/test_metadater.py
@@ -9,6 +9,8 @@
 
 """cernopendata-client file metadater test."""
 
+import pytest
+
 from click.testing import CliRunner
 from cernopendata_client.cli import get_metadata
 

--- a/tests/test_metadater.py
+++ b/tests/test_metadater.py
@@ -108,3 +108,38 @@ def test_get_metadata_from_filter_metadata_wrong_two():
     assert (
         "No objects found with url=/docs/cms-getting-started-20" in test_result.output
     )
+
+
+@pytest.mark.local
+def test_filter_matching_output_without_output_field(capsys):
+    """Test filter_matching_output when output_field is not in object."""
+    matching_objects = {"name_0": {"foo": "bar", "baz": "qux"}}
+    output_json = [{"foo": "bar", "baz": "qux"}]
+    filter_matching_output(matching_objects, "nonexistent", output_json)
+    captured = capsys.readouterr()
+    assert '"foo": "bar"' in captured.out
+    assert '"baz": "qux"' in captured.out
+
+
+@pytest.mark.local
+def test_filter_matching_output_multiple_matches_without_output_field(capsys):
+    """Test filter_matching_output with multiple matches when output_field is not in object."""
+    # Two different filter fields matching the same object at index 0
+    matching_objects = {
+        "field1_0": {"a": "1", "b": "2"},
+        "field2_0": {"a": "1", "b": "2"},
+    }
+    output_json = [{"a": "1", "b": "2"}]
+    filter_matching_output(matching_objects, "nonexistent", output_json)
+    captured = capsys.readouterr()
+    assert '"a": "1"' in captured.out
+    assert '"b": "2"' in captured.out
+
+
+@pytest.mark.local
+def test_filter_metadata_schema_field():
+    """Test filter_metadata when output_json contains $schema."""
+    output_json = ["$schema", {"name": "test"}]
+    with pytest.raises(SystemExit) as exc_info:
+        filter_metadata("name", ["name=test"], output_json)
+    assert exc_info.value.code == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ import pytest
 from cernopendata_client.utils import parse_parameters
 
 
+@pytest.mark.local
 def test_parse_parameters():
     """Test parse_parameters() method."""
     pytest.raises(SystemExit, parse_parameters, (9))

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -22,6 +22,7 @@ from cernopendata_client.validator import (
 )
 
 
+@pytest.mark.local
 def test_validate_recid():
     """Test validate_recid()."""
     pytest.raises(SystemExit, validate_recid, -1)
@@ -30,6 +31,7 @@ def test_validate_recid():
     assert validate_recid(1) is True
 
 
+@pytest.mark.local
 def test_validate_server():
     """Test validate_server()."""
     assert validate_server("http://opendata.cern.ch") is True
@@ -40,6 +42,7 @@ def test_validate_server():
     pytest.raises(SystemExit, validate_server, "opendata.cern.ch")
 
 
+@pytest.mark.local
 def test_validate_range():
     """Test validate_range()."""
     assert validate_range(range="3-9", count=10) is True
@@ -51,6 +54,7 @@ def test_validate_range():
     pytest.raises(SystemExit, validate_range, "3,2", 5)
 
 
+@pytest.mark.local
 def test_validate_directory():
     """Test validate_directory()."""
     assert validate_directory(directory="/eos/opendata/cms/validated-runs/") is True
@@ -62,6 +66,7 @@ def test_validate_directory():
     pytest.raises(SystemExit, validate_directory, 90)
 
 
+@pytest.mark.local
 def test_validate_retry_limit():
     """Test validate_retry_limit()."""
     pytest.raises(SystemExit, validate_retry_limit, -1)
@@ -70,6 +75,7 @@ def test_validate_retry_limit():
     assert validate_recid(1) is True
 
 
+@pytest.mark.local
 def test_validate_retry_sleep():
     """Test validate_retry_sleep()."""
     pytest.raises(SystemExit, validate_retry_sleep, -1)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -72,7 +72,7 @@ def test_validate_retry_limit():
     pytest.raises(SystemExit, validate_retry_limit, -1)
     pytest.raises(SystemExit, validate_retry_limit, 0)
     pytest.raises(SystemExit, validate_retry_limit, None)
-    assert validate_recid(1) is True
+    assert validate_retry_limit(1) is True
 
 
 @pytest.mark.local
@@ -81,4 +81,4 @@ def test_validate_retry_sleep():
     pytest.raises(SystemExit, validate_retry_sleep, -1)
     pytest.raises(SystemExit, validate_retry_sleep, 0)
     pytest.raises(SystemExit, validate_retry_sleep, None)
-    assert validate_recid(1) is True
+    assert validate_retry_sleep(1) is True

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -25,16 +25,18 @@ from cernopendata_client.verifier import (
 )
 
 
+@pytest.mark.local
 def test_get_file_size():
     """Test get_file_size()."""
     afile = "./tests/test_version.py"
-    assert get_file_size(afile) == 641
+    assert get_file_size(afile) == 675
 
 
+@pytest.mark.local
 def test_get_file_checksum():
     """Test get_file_checksum()."""
     afile = "./tests/test_version.py"
-    assert get_file_checksum(afile) == "adler32:fa91da1e"
+    assert get_file_checksum(afile) == "adler32:ac0ae69b"
 
 
 def test_get_file_checksum_zero_padding():
@@ -58,6 +60,7 @@ def test_get_file_checksum_zero_padding():
         os.remove(tmp_path)
 
 
+@pytest.mark.local
 def test_get_file_info_local_wrong_input():
     """Test get_file_info_local() for wrong inputs."""
 
@@ -194,6 +197,7 @@ def test_get_file_info_local_good_input_wrong_size():
         os.remove(test_file)
 
 
+@pytest.mark.local
 def test_verify_file_info_good_input():
     """Test verify_file_info() for good input."""
 
@@ -237,6 +241,7 @@ def test_verify_file_info_good_input():
     assert verify_file_info(test_file_info_local, test_file_info_remote) is True
 
 
+@pytest.mark.local
 def test_verify_file_info_wrong_input():
     """Test verify_file_info() for wrong input."""
 
@@ -281,6 +286,7 @@ def test_verify_file_info_wrong_input():
     )
 
 
+@pytest.mark.local
 def test_verify_file_info_wrong_checksum():
     """Test verify_file_info() for wrong checksum."""
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,11 +7,14 @@
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
 """cernopendata-client version test."""
 
+import pytest
+
 from cernopendata_client import __version__
 from click.testing import CliRunner
 from cernopendata_client.cli import version
 
 
+@pytest.mark.local
 def test_version():
     """Test version import."""
     test_version = CliRunner()


### PR DESCRIPTION
Mark tests that run without network access with @pytest.mark.local, allowing quick test runs during development. Remote tests (connecting to the CERN Open Data portal) remain unmarked and run by default.