### PR TITLE
feat(etc): add bash and zsh shell completion files 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ pytest
   - `walker.py` - Directory traversal
 - `tests/` - Test suite
 - `docs/` - Sphinx documentation
+- `etc/` - Shell completion files (bash/zsh)
 
 ## Code Style
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,4 +17,5 @@ recursive-include cernopendata_client *.py
 recursive-include docs *.png
 recursive-include docs *.py
 recursive-include docs *.md
+recursive-include etc *
 recursive-include tests *.py

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,6 +21,22 @@ verify-files        Verify downloaded data file integrity.
 version             Return cernopendata-client version.
 ```
 
+Note that the `cernopendata-client` supports shell completion for Bash and Zsh.
+To enable the auto-completion of commands and options, add the following to your
+shell configuration file:
+
+**Bash** (add to `~/.bashrc`):
+
+```bash
+eval "$(_CERNOPENDATA_CLIENT_COMPLETE=bash_source cernopendata-client)"
+```
+
+**Zsh** (add to `~/.zshrc`):
+
+```bash
+eval "$(_CERNOPENDATA_CLIENT_COMPLETE=zsh_source cernopendata-client)"
+```
+
 ## Selecting records
 
 The data published on the [CERN Open Data portal](http://opendata.cern.ch) are

--- a/etc/bash_completion.d/cernopendata-client
+++ b/etc/bash_completion.d/cernopendata-client
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# This file is part of cernopendata-client.
+#
+# Copyright (C) 2025 CERN.
+#
+# cernopendata-client is free software; you can redistribute it and/or modify
+# it under the terms of the GPLv3 license; see LICENSE file for more details.
+
+# Bash completion for cernopendata-client
+# Generated using Click shell completion (Click 8.x)
+#
+# Installation:
+#   Option 1: Source this file in your .bashrc:
+#     . /path/to/cernopendata-client/etc/bash_completion.d/cernopendata-client
+#
+#   Option 2: Copy to system completion directory:
+#     cp /path/to/cernopendata-client/etc/bash_completion.d/cernopendata-client \
+#        /etc/bash_completion.d/
+#
+#   Option 3: Generate dynamically (add to .bashrc):
+#     eval "$(_CERNOPENDATA_CLIENT_COMPLETE=bash_source cernopendata-client)"
+
+_cernopendata_client_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _CERNOPENDATA_CLIENT_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_cernopendata_client_completion_setup() {
+    complete -o nosort -F _cernopendata_client_completion cernopendata-client
+}
+
+_cernopendata_client_completion_setup;

--- a/etc/zsh_completion.d/_cernopendata-client
+++ b/etc/zsh_completion.d/_cernopendata-client
@@ -1,0 +1,62 @@
+#compdef cernopendata-client
+# -*- coding: utf-8 -*-
+# This file is part of cernopendata-client.
+#
+# Copyright (C) 2025 CERN.
+#
+# cernopendata-client is free software; you can redistribute it and/or modify
+# it under the terms of the GPLv3 license; see LICENSE file for more details.
+
+# Zsh completion for cernopendata-client
+# Generated using Click shell completion (Click 8.x)
+#
+# Installation:
+#   Option 1: Add directory to fpath in your .zshrc (before compinit):
+#     fpath=(/path/to/cernopendata-client/etc/zsh_completion.d $fpath)
+#     autoload -Uz compinit && compinit
+#
+#   Option 2: Copy to system completion directory:
+#     cp /path/to/cernopendata-client/etc/zsh_completion.d/_cernopendata-client \
+#        /usr/local/share/zsh/site-functions/
+#
+#   Option 3: Generate dynamically (add to .zshrc):
+#     eval "$(_CERNOPENDATA_CLIENT_COMPLETE=zsh_source cernopendata-client)"
+
+_cernopendata_client_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[cernopendata-client] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _CERNOPENDATA_CLIENT_COMPLETE=zsh_complete cernopendata-client)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _cernopendata_client_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _cernopendata_client_completion cernopendata-client
+fi


### PR DESCRIPTION
Add shell completion scripts for `cernopendata-client` generated using 
Click's shell completion feature. The completions work dynamically by
querying the CLI at completion time, so they don't need updating when
the CLI commands change. Just beware when upgrading Click major version.

Enrich usage documentation with information about how to enable
bash and zsh shell completion for `cernopendata-client`.

