### PR TITLE
Explicitly close files to prevent resource leak

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,3 +13,4 @@ The list of contributors in alphabetical order:
 - [Pablo Saiz](https://github.com/psaiz)
 - [Parth Shandilya](https://github.com/ParthS007)
 - [Tibor Simko](https://orcid.org/0000-0001-7202-5803)
+- [Zhuohang Shen](https://github.com/Stephen0512)

--- a/cernopendata_client/verifier.py
+++ b/cernopendata_client/verifier.py
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020, 2025 CERN.
+# Copyright (C) 2020, 2025, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -38,9 +38,8 @@ def get_file_checksum(afile):
     :return: Adler32 checksum of file
     :rtype: str
     """
-    return "adler32:{:08x}".format(
-        zlib.adler32(open(afile, "rb").read(), 1) & 0xFFFFFFFF
-    )
+    with open(afile, "rb") as f:
+        return "adler32:{:08x}".format(zlib.adler32(f.read(), 1) & 0xFFFFFFFF)
 
 
 def get_file_info_local(recid):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -13,9 +13,10 @@ import re
 
 from setuptools import setup
 
-readme = open("README.md").read()
-history = open("CHANGELOG.md").read()
-
+with open("README.md", "r") as f:
+    readme = f.read()
+with open("CHANGELOG.md", "r") as f:
+    history = f.read()
 
 extras_require = {
     "docs": [


### PR DESCRIPTION
This pull request fixes a file-handling issue in the `verifier`. The current implementation uses `open()` without explicitly closing the file, which can potentially lead to resource leaks. While Python's garbage collector will eventually close the file once it is no longer referenced, it is generally better practice to explicitly close files or use a context manager.

This change replaces the direct `open()` call with a `with` statement to ensure proper file closure and follow Python best practices. The issue was identified during an ongoing research project.

