### PR TITLE
fix(docker): limit ubuntu user to primary group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2020, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -59,9 +59,10 @@ RUN pip3 install --no-cache-dir '.[pycurl,tests,xrootd]' && \
     rm -rf /code
 
 # Run container as `ubuntu` user with UID `1000`, which should match
-# current host user in most situations
+# current host user in most situations. Specify the primary group explicitly
+# so that container processes do not inherit extra supplementary groups.
 RUN chown -R ubuntu /code
-USER ubuntu
+USER ubuntu:ubuntu
 
 # Run cernopendata-client upon entry
 ENTRYPOINT ["cernopendata-client"]

--- a/cernopendata_client/config.py
+++ b/cernopendata_client/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of cernopendata-client.
-# Copyright (C) 2020, 2021, 2025 CERN.
+# Copyright (C) 2020, 2021, 2025, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2019, 2020, 2021, 2023, 2024, 2025 CERN.
+# Copyright (C) 2019, 2020, 2021, 2023, 2024, 2025, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -65,7 +65,7 @@ lint_manifest() {
 }
 
 lint_hadolint() {
-    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 <Dockerfile
+    docker run -i --rm docker.io/hadolint/hadolint:v2.14.0 <Dockerfile
 }
 
 docker_build() {


### PR DESCRIPTION
Run the container as `ubuntu:ubuntu` instead of `ubuntu` so Docker does not include the Ubuntu base image's supplementary groups (such as adm, video, etc) at runtime. This keeps the existing non-root UID 1000 behavior while making the container identity more precise.