### PR TITLE
fix(walker): report concrete XRootD client errors

### DIFF
--- a/cernopendata_client/downloader.py
+++ b/cernopendata_client/downloader.py
@@ -180,24 +180,26 @@ class DownloaderXrootd:
 
     def file_downloader(self):
         """Download single file with XRootD."""
-        try:
+        display_message(
+            msg_type="note",
+            msg="File: ./{}/{}".format(
+                self.path,
+                self.file_name,
+            ),
+        )
+        process = xrootdclient.CopyProcess()
+        process.add_job(
+            SERVER_ROOT_URI + self.file_src, os.getcwd() + os.sep + self.file_dest
+        )
+        status = process.prepare()
+        if status.ok:
+            status, _ = process.run()
+        if not status.ok:
             display_message(
-                msg_type="note",
-                msg="File: ./{}/{}".format(
-                    self.path,
-                    self.file_name,
-                ),
+                msg_type="error",
+                msg="Download error: {}".format(status.message.strip()),
             )
-            process = xrootdclient.CopyProcess()
-            process.add_job(
-                SERVER_ROOT_URI + self.file_src, os.getcwd() + os.sep + self.file_dest
-            )
-            process.prepare()
-            process.run()
-        except Exception:
-            display_message(
-                msg_type="error", msg="Download error occured. Please try again."
-            )
+            sys.exit(1)
 
 
 def check_error(

--- a/cernopendata_client/walker.py
+++ b/cernopendata_client/walker.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020, 2021 CERN.
+# Copyright (C) 2020, 2021, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -17,14 +17,24 @@ import datetime
 from .config import SERVER_ROOT_URI
 from .printer import display_message
 
+# XRootD client error code for a not-found path. Resolved at import time and
+# left as None for older bindings that do not expose it; the wire-protocol
+# errno below is the stable fallback.
+XROOTD_CODE_NOT_FOUND = None
+
 try:
     from XRootD import client as xrootdclient
-    from XRootD.client.flags import DirListFlags
+    from XRootD.client.flags import DirListFlags, StatInfoFlags
+    from XRootD.client.responses import XRootDStatus
 
+    XROOTD_CODE_NOT_FOUND = getattr(XRootDStatus, "errNotFound", None)
     FS = xrootdclient.FileSystem(SERVER_ROOT_URI)
     xrootd_available = True
 except ImportError:
     xrootd_available = False
+
+# XRootD server error number returned when a path does not exist (kXR_NotFound).
+XROOTD_ERRNO_NOT_FOUND = 3011
 
 
 def get_list_directory(path, recursive, timeout, time_start=None):
@@ -57,24 +67,35 @@ def get_list_directory(path, recursive, timeout, time_start=None):
         )
         sys.exit(2)
     files = []
-    try:
-        status, listing = FS.dirlist(path, DirListFlags.STAT)
-        for entry in listing:
-            if entry.statinfo.flags == 19:  # entry is a directory
-                files.append(path + os.sep + entry.name)
-                if recursive:
-                    files.extend(
-                        get_list_directory(
-                            path + os.sep + entry.name, recursive, timeout, time_start
-                        )
-                    )
-            else:
-                files.append(path + os.sep + entry.name)
-        return files
-    except Exception:
-        display_message(
-            msg_type="error",
-            msg="Directory {} does not exist.".format(path),
+    status, listing = FS.dirlist(path, DirListFlags.STAT)
+    if not status.ok:
+        # A missing path is reported via the stable server error number, or,
+        # when the binding exposes it, the client-level not-found code.
+        path_not_found = status.errno == XROOTD_ERRNO_NOT_FOUND or (
+            XROOTD_CODE_NOT_FOUND is not None and status.code == XROOTD_CODE_NOT_FOUND
         )
+        if path_not_found:
+            display_message(
+                msg_type="error",
+                msg="Directory {} does not exist.".format(path),
+            )
+        else:
+            display_message(
+                msg_type="error",
+                msg="Cannot list directory {}: {}".format(path, status.message.strip()),
+            )
         sys.exit(1)
+    required_directory_flags = (
+        StatInfoFlags.X_BIT_SET | StatInfoFlags.IS_DIR | StatInfoFlags.IS_READABLE
+    )
+    for entry in listing:
+        entry_path = path + os.sep + entry.name
+        files.append(entry_path)
+        if (
+            entry.statinfo.flags & required_directory_flags
+        ) == required_directory_flags:
+            if recursive:
+                files.extend(
+                    get_list_directory(entry_path, recursive, timeout, time_start)
+                )
     return files


### PR DESCRIPTION
Stop masking XRootD failures behind generic download and directory
messages. Check the status objects returned by CopyProcess.prepare(),
CopyProcess.run(), and FileSystem.dirlist(), and surface the underlying
XRootD message when the operation fails.

Keep the existing user-facing "directory does not exist" message for
missing paths by recognising both the XRootD client not-found status and
the server-side kXR_NotFound errno.

Note that a failed XRootD transfer now aborts the command with exit
code 1 instead of continuing to the next file, which could previously
end in an unhandled error or a misleading "Success!".

Detect traversable directory entries using the named XRootD X_BIT_SET,
IS_DIR, and IS_READABLE flags instead of comparing the complete flag
value to numeric mask 19. This skips inaccessible directories while
allowing readable directories with additional flags to be traversed.
Append each listed path only once.
