### PR TITLE
feat(download): verify downloaded files by default

### DIFF
--- a/cernopendata_client/cli.py
+++ b/cernopendata_client/cli.py
@@ -16,7 +16,7 @@ import sys
 import re
 
 from .searcher import (
-    get_file_info_remote,
+    get_file_entries,
     get_files_list,
     get_recid,
     get_recid_api,
@@ -29,8 +29,7 @@ from .downloader import (
     get_download_files_by_name,
     get_download_files_by_range,
     get_download_files_by_regexp,
-    get_download_path,
-    get_file_subdirectories,
+    get_download_items,
 )
 from .validator import (
     validate_range,
@@ -41,7 +40,7 @@ from .validator import (
     validate_retry_sleep,
 )
 from .walker import get_list_directory
-from .verifier import get_file_info_local, verify_file_info
+from .verifier import get_local_file_paths, verify_downloaded_file
 from .metadater import filter_metadata, handle_error_message
 from .config import (
     SERVER_HTTP_URI,
@@ -245,11 +244,10 @@ def get_file_locations(server, recid, doi, title, protocol, expand, verbose):
     help="Download files from a specified list range (i-j)",
 )
 @click.option(
-    "--verify",
+    "--verify/--no-verify",
     "verify",
-    is_flag=True,
-    default=False,
-    help="Verify downloaded data file integrity",
+    default=True,
+    help="Verify downloaded data file checksums when available [default=yes]",
 )
 @click.option(
     "--retry-limit",
@@ -316,8 +314,8 @@ def download_files(
     # Get record metadata and resolve recid from DOI/title if needed
     record_json = get_record_as_json(server, recid, doi, title)
     record_recid = record_json["metadata"]["recid"]
-    file_locations_info = get_files_list(server, record_json, protocol, expand)
-    file_locations = [file_[0] for file_ in file_locations_info]
+    file_entries = get_file_entries(server, record_json, protocol, expand)
+    file_locations = [entry.uri for entry in file_entries]
     download_file_locations = []
 
     if names:
@@ -352,12 +350,18 @@ def download_files(
     else:
         download_file_locations = file_locations
 
+    file_entries_by_location = {entry.uri: entry for entry in file_entries}
+    download_file_entries = [
+        file_entries_by_location[file_location]
+        for file_location in download_file_locations
+    ]
+
     if dryrun:
         display_message(msg="\n".join(download_file_locations))
         sys.exit(0)
 
     total_files = len(download_file_locations)
-    base_path = record_recid
+    base_path = str(record_recid)
     if not os.path.isdir(base_path):
         try:
             os.mkdir(base_path)
@@ -366,42 +370,49 @@ def download_files(
                 msg_type="error",
                 msg="Creation of the directory {} failed".format(base_path),
             )
-    file_subdirs = get_file_subdirectories(download_file_locations)
+    download_items = get_download_items(
+        base_path, download_file_entries, layout_entries=file_entries
+    )
     if not download_engine:
         if protocol.startswith("http"):
             download_engine = "requests"
         elif protocol == "xrootd":
             download_engine = "xrootd"
-    for file_location in download_file_locations:
-        path = get_download_path(base_path, file_location, file_subdirs)
+    for file_number, download_item in enumerate(download_items, start=1):
+        os.makedirs(download_item.destination_directory, exist_ok=True)
         display_message(
             msg_type="info",
-            msg="Downloading file {} of {}".format(
-                download_file_locations.index(file_location) + 1, total_files
-            ),
+            msg="Downloading file {} of {}".format(file_number, total_files),
         )
         download_single_file(
-            path=path,
-            file_location=file_location,
+            path=download_item.destination_directory,
+            file_location=download_item.file_location,
             protocol=protocol,
             download_engine=download_engine,
+            expected_size=download_item.expected_size,
         )
         check_error(
-            path=path,
-            file_location=file_location,
+            path=download_item.destination_directory,
+            file_location=download_item.file_location,
             protocol=protocol,
             retry_limit=retry_limit,
             retry_sleep=retry_sleep,
+            download_engine=download_engine,
         )
-        if verify:
-            file_info_remote = get_file_info_remote(
-                server,
-                record_recid,
-                protocol=protocol,
-                filtered_files=[file_location],
+        verify_downloaded_file(
+            download_item.destination_path,
+            expected_size=download_item.expected_size,
+            expected_checksum=download_item.expected_checksum,
+            verify_checksum=verify,
+        )
+        if download_item.is_file_index:
+            display_message(
+                msg_type="note",
+                msg=(
+                    "Skipping metadata size and checksum checks for the "
+                    "unexpanded file-index response."
+                ),
             )
-            file_info_local = get_file_info_local(record_recid)
-            verify_file_info(file_info_local, file_info_remote)
     display_message(
         msg_type="info",
         msg="Success!",
@@ -437,12 +448,17 @@ def verify_files(server, recid, doi, title):
     record_json = get_record_as_json(server, recid, doi, title)
     record_recid = record_json["metadata"]["recid"]
 
-    # Get remote file information
-    file_info_remote = get_file_info_remote(server, record_recid)
+    file_entries = get_file_entries(
+        server=server,
+        record_json=record_json,
+        protocol=server.split(":", 1)[0],
+        expand=True,
+    )
+    download_items = get_download_items(str(record_recid), file_entries)
 
     # Get local file information
-    file_info_local = get_file_info_local(record_recid)
-    if not file_info_local:
+    local_file_paths = get_local_file_paths(str(record_recid))
+    if not local_file_paths:
         display_message(
             msg_type="error",
             msg="No local files found for record {}. Perhaps run `download-files` first? Exiting.".format(
@@ -458,17 +474,22 @@ def verify_files(server, recid, doi, title):
     )
     display_message(
         msg_type="note",
-        msg="Expected {}, found {}".format(len(file_info_remote), len(file_info_local)),
+        msg="Expected {}, found {}".format(len(download_items), len(local_file_paths)),
     )
-    if len(file_info_remote) != len(file_info_local):
+    if len(download_items) != len(local_file_paths):
         display_message(
             msg_type="error",
             msg="File count does not match.",
         )
         sys.exit(1)
 
-    # Verify size and checksum of each file
-    verify_file_info(file_info_local, file_info_remote)
+    # Verify size and checksum of each exact destination
+    for download_item in download_items:
+        verify_downloaded_file(
+            download_item.destination_path,
+            expected_size=download_item.expected_size,
+            expected_checksum=download_item.expected_checksum,
+        )
 
     # Success!
     display_message(

--- a/cernopendata_client/downloader.py
+++ b/cernopendata_client/downloader.py
@@ -9,6 +9,9 @@
 """cernopendata-client file downloading related utilities."""
 
 from __future__ import print_function
+from dataclasses import dataclass
+from typing import Optional
+
 import sys
 import os
 import re
@@ -45,6 +48,18 @@ from .config import (
     DOWNLOAD_ENGINE_PROTOCOL_XROOTD_MAP,
     SERVER_ROOT_URI,
 )
+
+
+@dataclass(frozen=True)
+class DownloadItem:
+    """Describe one selected download and its exact local destination."""
+
+    file_location: str
+    expected_size: Optional[int]
+    expected_checksum: Optional[str]
+    destination_directory: str
+    destination_path: str
+    is_file_index: bool = False
 
 
 class DownloaderHttpRequests:
@@ -203,7 +218,12 @@ class DownloaderXrootd:
 
 
 def check_error(
-    path=None, file_location=None, protocol=None, retry_limit=None, retry_sleep=None
+    path=None,
+    file_location=None,
+    protocol=None,
+    retry_limit=None,
+    retry_sleep=None,
+    download_engine=None,
 ):
     """Return True if the file size and checksum does not matches with download error page.
 
@@ -212,46 +232,47 @@ def check_error(
     :param protocol: Protocol to be used for downloading a file
     :param retry_limit: Number of retries to be made for downloading a file.
     :param retry_sleep: Time of sleep before every retry.
+    :param download_engine: Library to be used in downloading files.
     :type path: str
     :type file_location: str
     :type protocol: str
     :type retry_limit: int
     :type retry_sleep: int
+    :type download_engine: str
 
     :return: True if the file size and checksum does not matches with download error page.
     :rtype: Boolean
     """
     file_name = file_location.split("/")[-1]
-    file_dest = path + "/" + file_name
-    downloaded_file = {
-        "size": os.path.getsize(file_dest),
-        "checksum": get_file_checksum(file_dest),
-    }
-    if (
-        DOWNLOAD_ERROR_PAGE["size"] == downloaded_file["size"]
-        and DOWNLOAD_ERROR_PAGE["checksum"] == downloaded_file["checksum"]
-    ):
-        for _retry in range(0, retry_limit + 1):
-            if _retry == retry_limit:
-                display_message(msg_type="error", msg="Number of retries exceeded.")
-                sys.exit(1)
-            display_message(
-                msg_type="note", msg="Retrying {}/{}".format(_retry + 1, retry_limit)
-            )
-            time.sleep(retry_sleep)
-            download_single_file(
-                path=path, file_location=file_location, protocol=protocol
-            )
-            downloaded_file = {
-                "size": os.path.getsize(file_dest),
-                "checksum": get_file_checksum(file_dest),
-            }
-            error = (
-                DOWNLOAD_ERROR_PAGE["size"] == downloaded_file["size"]
-                and DOWNLOAD_ERROR_PAGE["checksum"] == downloaded_file["checksum"]
-            )
-            if not error:
-                return True
+    file_dest = os.path.join(path, file_name)
+    if not _is_download_error_page(file_dest):
+        return True
+
+    for _retry in range(0, retry_limit or 0):
+        display_message(
+            msg_type="note", msg="Retrying {}/{}".format(_retry + 1, retry_limit)
+        )
+        time.sleep(retry_sleep)
+        download_single_file(
+            path=path,
+            file_location=file_location,
+            protocol=protocol,
+            download_engine=download_engine,
+        )
+        if not _is_download_error_page(file_dest):
+            return True
+
+    display_message(msg_type="error", msg="Number of retries exceeded.")
+    sys.exit(1)
+
+
+def _is_download_error_page(file_dest):
+    """Return whether a destination contains the known download error page."""
+    if not os.path.isfile(file_dest):
+        return False
+    if os.path.getsize(file_dest) != DOWNLOAD_ERROR_PAGE["size"]:
+        return False
+    return get_file_checksum(file_dest) == DOWNLOAD_ERROR_PAGE["checksum"]
 
 
 def downloader_file_checker(file_location, file_dest):
@@ -280,7 +301,11 @@ def downloader_file_checker(file_location, file_dest):
 
 
 def download_single_file(
-    path=None, file_location=None, protocol=None, download_engine=None
+    path=None,
+    file_location=None,
+    protocol=None,
+    download_engine=None,
+    expected_size=None,
 ):
     """Download a single file.
 
@@ -288,10 +313,12 @@ def download_single_file(
     :param file_location: Remote location of a file
     :param protocol: Protocol to be used for downloading a file
     :param download_engine: Library to be used in downloading files
+    :param expected_size: Final file size from record metadata, if applicable
     :type path: str
     :type file_location: str
     :type protocol: str
     :type download_engine: str
+    :type expected_size: int
 
     :return: None
     :rtype: None
@@ -322,7 +349,9 @@ def download_single_file(
                 ),
             )
             sys.exit(1)
-        file_download_incomplete = downloader_file_checker(file_location, file_dest)
+        file_download_incomplete = False
+        if os.path.isfile(file_dest) and expected_size is not None:
+            file_download_incomplete = os.path.getsize(file_dest) < expected_size
         if file_download_incomplete:
             file_size_offline = os.path.getsize(file_dest)
             mode = "ab"
@@ -423,6 +452,44 @@ def get_download_path(base_path, file_location, file_subdirs):
         os.makedirs(path, exist_ok=True)
         return path
     return base_path
+
+
+def get_download_items(base_path, file_entries, layout_entries=None):
+    """Return selected downloads with exact destinations and metadata.
+
+    :param base_path: Base directory for downloads
+    :param file_entries: Selected file metadata entries
+    :param layout_entries: All entries used to disambiguate destination paths
+    :type base_path: str
+    :type file_entries: list
+    :type layout_entries: list
+
+    :return: Selected downloads with exact destinations and metadata
+    :rtype: list
+    """
+    layout_entries = layout_entries if layout_entries is not None else file_entries
+    file_locations = [entry.uri for entry in layout_entries]
+    file_subdirs = get_file_subdirectories(file_locations)
+    download_items = []
+    for entry in file_entries:
+        subdir = file_subdirs[entry.uri]
+        destination_directory = os.path.join(base_path, subdir) if subdir else base_path
+        destination_path = os.path.join(
+            destination_directory, entry.uri.rsplit("/", 1)[-1]
+        )
+        download_items.append(
+            DownloadItem(
+                file_location=entry.uri,
+                expected_size=None if entry.is_file_index else entry.size,
+                expected_checksum=(
+                    None if entry.is_file_index else entry.checksum or None
+                ),
+                destination_directory=destination_directory,
+                destination_path=destination_path,
+                is_file_index=entry.is_file_index,
+            )
+        )
+    return download_items
 
 
 def get_download_files_by_name(names=None, file_locations=None):

--- a/cernopendata_client/searcher.py
+++ b/cernopendata_client/searcher.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020, 2024, 2025 CERN.
+# Copyright (C) 2020, 2024, 2025, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -13,10 +13,21 @@ from __future__ import print_function
 import sys
 import requests
 
+from dataclasses import dataclass
 from urllib.parse import quote
 
 from .config import SERVER_HTTP_URI, SERVER_ROOT_URI, SERVER_HTTPS_URI
 from .printer import display_message
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    """Describe a downloadable file and its verification metadata."""
+
+    uri: str
+    size: int
+    checksum: str
+    is_file_index: bool = False
 
 
 def verify_recid(server=None, recid=None):
@@ -188,6 +199,14 @@ def get_files_list(
     :return: List of files list
     :rtype: list
     """
+    return [
+        (entry.uri, entry.size, entry.checksum)
+        for entry in get_file_entries(server, record_json, protocol, expand)
+    ]
+
+
+def get_file_entries(server=None, record_json=None, protocol=None, expand=None):
+    """Return downloadable files with their metadata and origin."""
     searcher_protocol = protocol
     if server != SERVER_HTTP_URI and searcher_protocol != "xrootd":
         searcher_protocol = server.split(":")[0]
@@ -199,10 +218,10 @@ def get_files_list(
 
     for file_ in record_json["metadata"].get("files", []):
         files_list.append(
-            (
-                file_["uri"].replace(SERVER_ROOT_URI, new_server),
-                file_["size"],
-                file_["checksum"],
+            FileEntry(
+                uri=file_["uri"].replace(SERVER_ROOT_URI, new_server),
+                size=file_["size"],
+                checksum=file_.get("checksum", ""),
             )
         )
     for file_ in record_json["metadata"].get("_file_indices", []):
@@ -210,18 +229,21 @@ def get_files_list(
             # let's unwind file indexes
             for inner_file in file_["files"]:
                 files_list.append(
-                    (
-                        inner_file["uri"].replace(SERVER_ROOT_URI, new_server),
-                        inner_file["size"],
-                        inner_file["checksum"],
+                    FileEntry(
+                        uri=inner_file["uri"].replace(SERVER_ROOT_URI, new_server),
+                        size=inner_file["size"],
+                        checksum=inner_file.get("checksum", ""),
                     )
                 )
         else:
+            # The index size is the aggregate size of its data files, not the
+            # byte size of the JSON response returned by this synthetic URI.
             files_list.append(
-                (
-                    f"{new_server}/record/{record_json['metadata']['recid']}/file_index/{file_['key']}",
-                    file_["size"],
-                    "",
+                FileEntry(
+                    uri=f"{new_server}/record/{record_json['metadata']['recid']}/file_index/{file_['key']}",
+                    size=file_["size"],
+                    checksum="",
+                    is_file_index=True,
                 )
             )
     return files_list

--- a/cernopendata_client/verifier.py
+++ b/cernopendata_client/verifier.py
@@ -11,10 +11,11 @@
 
 import os
 import sys
-import click
 import zlib
 
 from .printer import display_message
+
+CHECKSUM_CHUNK_SIZE = 1024 * 1024
 
 
 def get_file_size(afile):
@@ -38,8 +39,26 @@ def get_file_checksum(afile):
     :return: Adler32 checksum of file
     :rtype: str
     """
+    checksum = 1
     with open(afile, "rb") as f:
-        return "adler32:{:08x}".format(zlib.adler32(f.read(), 1) & 0xFFFFFFFF)
+        while True:
+            chunk = f.read(CHECKSUM_CHUNK_SIZE)
+            if not chunk:
+                break
+            checksum = zlib.adler32(chunk, checksum)
+    return "adler32:{:08x}".format(checksum & 0xFFFFFFFF)
+
+
+def get_local_file_paths(adir):
+    """Return all regular files below a directory in deterministic order."""
+    local_file_paths = []
+    if not os.path.isdir(adir):
+        return local_file_paths
+    for root, directories, files in os.walk(adir):
+        directories.sort()
+        for afile in sorted(files):
+            local_file_paths.append(os.path.join(root, afile))
+    return local_file_paths
 
 
 def get_file_info_local(recid):
@@ -68,6 +87,55 @@ def get_file_info_local(recid):
         )
 
     return file_info_local
+
+
+def verify_downloaded_file(
+    afile,
+    expected_size=None,
+    expected_checksum=None,
+    verify_checksum=True,
+):
+    """Verify one exact local path against the supplied record metadata."""
+    display_message(
+        msg_type="info",
+        msg="Verifying file {}... ".format(afile),
+    )
+    if not os.path.isfile(afile):
+        display_message(
+            msg_type="error",
+            msg="Downloaded file is missing: {}.".format(afile),
+        )
+        sys.exit(1)
+
+    actual_size = get_file_size(afile)
+    if expected_size is not None:
+        display_message(
+            msg_type="note",
+            msg="Expected size {}, found {}".format(expected_size, actual_size),
+        )
+        if expected_size != actual_size:
+            size_failure = "incomplete" if actual_size < expected_size else "oversized"
+            display_message(
+                msg_type="error",
+                msg="File size does not match; the file is {}.".format(size_failure),
+            )
+            sys.exit(1)
+
+    if verify_checksum and expected_checksum:
+        actual_checksum = get_file_checksum(afile)
+        display_message(
+            msg_type="note",
+            msg="Expected checksum {}, found {}".format(
+                expected_checksum, actual_checksum
+            ),
+        )
+        if expected_checksum != actual_checksum:
+            display_message(
+                msg_type="error",
+                msg="File checksum does not match.",
+            )
+            sys.exit(1)
+    return True
 
 
 def verify_file_info(file_info_local, file_info_remote):

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -199,7 +199,26 @@ http://opendata.cern.ch/eos/opendata/cms/software/HiggsExample20112012/mass4l_co
 
 In order to download data files belonging to a record, please use the
 **download-files** command. The command can download files over HTTP, HTTPS or
-XRootD protocols and verify the file checksums.
+XRootD protocols. Every downloaded destination is compared with the size in the
+record metadata, and its Adler-32 checksum is verified by default when one is
+available. Use `--no-verify` to skip checksum calculation; the size check is
+always performed so incomplete or oversized transfers cannot report success.
+
+When `--no-expand` downloads a file-index JSON document, its metadata size
+describes the aggregate indexed data rather than the JSON response. The client
+therefore checks that the exact index destination exists and is not a known
+download error page, but explicitly skips the inapplicable size and checksum
+comparisons for that response.
+
+For example, the following command still validates the downloaded byte count but
+omits the checksum pass:
+
+```console
+$ cernopendata-client download-files --recid 5500 --no-verify
+```
+
+The first HTTP example below shows the complete verification output. Later
+download transcripts omit repeated verification messages for brevity.
 
 **HTTP protocol**
 
@@ -210,36 +229,69 @@ $ cernopendata-client download-files --recid 5500
 ==> Downloading file 1 of 11
   -> File: ./5500/BuildFile.xml
   -> Progress: 0/0 KiB (100%)
+==> Verifying file 5500/BuildFile.xml...
+  -> Expected size 305, found 305
+  -> Expected checksum adler32:ff63668a, found adler32:ff63668a
 ==> Downloading file 2 of 11
   -> File: ./5500/HiggsDemoAnalyzer.cc
   -> Progress: 81/81 KiB (100%)
+==> Verifying file 5500/HiggsDemoAnalyzer.cc...
+  -> Expected size 83761, found 83761
+  -> Expected checksum adler32:f205f068, found adler32:f205f068
 ==> Downloading file 3 of 11
   -> File: ./5500/List_indexfile.txt
   -> Progress: 1/1 KiB (100%)
+==> Verifying file 5500/List_indexfile.txt...
+  -> Expected size 1669, found 1669
+  -> Expected checksum adler32:46a907fc, found adler32:46a907fc
 ==> Downloading file 4 of 11
   -> File: ./5500/M4Lnormdatall.cc
   -> Progress: 14/14 KiB (100%)
+==> Verifying file 5500/M4Lnormdatall.cc...
+  -> Expected size 14943, found 14943
+  -> Expected checksum adler32:af301992, found adler32:af301992
 ==> Downloading file 5 of 11
   -> File: ./5500/M4Lnormdatall_lvl3.cc
   -> Progress: 15/15 KiB (100%)
+==> Verifying file 5500/M4Lnormdatall_lvl3.cc...
+  -> Expected size 15805, found 15805
+  -> Expected checksum adler32:9d9b2126, found adler32:9d9b2126
 ==> Downloading file 6 of 11
   -> File: ./5500/demoanalyzer_cfg_level3MC.py
   -> Progress: 3/3 KiB (100%)
+==> Verifying file 5500/demoanalyzer_cfg_level3MC.py...
+  -> Expected size 3741, found 3741
+  -> Expected checksum adler32:cc943381, found adler32:cc943381
 ==> Downloading file 7 of 11
   -> File: ./5500/demoanalyzer_cfg_level3data.py
   -> Progress: 3/3 KiB (100%)
+==> Verifying file 5500/demoanalyzer_cfg_level3data.py...
+  -> Expected size 3689, found 3689
+  -> Expected checksum adler32:1d3e2a43, found adler32:1d3e2a43
 ==> Downloading file 8 of 11
   -> File: ./5500/demoanalyzer_cfg_level4MC.py
   -> Progress: 3/3 KiB (100%)
+==> Verifying file 5500/demoanalyzer_cfg_level4MC.py...
+  -> Expected size 3874, found 3874
+  -> Expected checksum adler32:9cbd53a3, found adler32:9cbd53a3
 ==> Downloading file 9 of 11
   -> File: ./5500/demoanalyzer_cfg_level4data.py
   -> Progress: 3/3 KiB (100%)
+==> Verifying file 5500/demoanalyzer_cfg_level4data.py...
+  -> Expected size 3821, found 3821
+  -> Expected checksum adler32:177b49c0, found adler32:177b49c0
 ==> Downloading file 10 of 11
   -> File: ./5500/mass4l_combine.pdf
   -> Progress: 17/17 KiB (100%)
+==> Verifying file 5500/mass4l_combine.pdf...
+  -> Expected size 18170, found 18170
+  -> Expected checksum adler32:19c6a6a2, found adler32:19c6a6a2
 ==> Downloading file 11 of 11
   -> File: ./5500/mass4l_combine.png
   -> Progress: 90/90 KiB (100%)
+==> Verifying file 5500/mass4l_combine.png...
+  -> Expected size 93152, found 93152
+  -> Expected checksum adler32:62e0c299, found adler32:62e0c299
 ==> Success!
 ```
 
@@ -328,6 +380,12 @@ $ cernopendata-client download-files --recid 5500 --filter-name BuildFile.xml,Li
   -> Progress: 1/1 KiB (100%)
 ==> Success!
 ```
+
+When a record contains files with duplicate base names, filtered downloads keep
+the subdirectory layout derived from the complete record. For example, a file
+may be saved as `X/0002/AO2D.root` rather than `X/AO2D.root`. This prevents
+successive filtered downloads from overwriting one another and keeps their paths
+compatible with `verify-files`.
 
 **Filter by regular expression**
 
@@ -426,65 +484,65 @@ command:
 $ cernopendata-client verify-files --recid 5500
 ==> Verifying number of files for record 5500...
   -> Expected 11, found 11
-==> Verifying file BuildFile.xml...
+==> Verifying file 5500/BuildFile.xml...
   -> Expected size 305, found 305
   -> Expected checksum adler32:ff63668a, found adler32:ff63668a
-==> Verifying file HiggsDemoAnalyzer.cc...
+==> Verifying file 5500/HiggsDemoAnalyzer.cc...
   -> Expected size 83761, found 83761
   -> Expected checksum adler32:f205f068, found adler32:f205f068
-==> Verifying file List_indexfile.txt...
+==> Verifying file 5500/List_indexfile.txt...
   -> Expected size 1669, found 1669
   -> Expected checksum adler32:46a907fc, found adler32:46a907fc
-==> Verifying file M4Lnormdatall.cc...
+==> Verifying file 5500/M4Lnormdatall.cc...
   -> Expected size 14943, found 14943
   -> Expected checksum adler32:af301992, found adler32:af301992
-==> Verifying file M4Lnormdatall_lvl3.cc...
+==> Verifying file 5500/M4Lnormdatall_lvl3.cc...
   -> Expected size 15805, found 15805
   -> Expected checksum adler32:9d9b2126, found adler32:9d9b2126
-==> Verifying file demoanalyzer_cfg_level3MC.py...
+==> Verifying file 5500/demoanalyzer_cfg_level3MC.py...
   -> Expected size 3741, found 3741
   -> Expected checksum adler32:cc943381, found adler32:cc943381
-==> Verifying file demoanalyzer_cfg_level3data.py...
+==> Verifying file 5500/demoanalyzer_cfg_level3data.py...
   -> Expected size 3689, found 3689
   -> Expected checksum adler32:1d3e2a43, found adler32:1d3e2a43
-==> Verifying file demoanalyzer_cfg_level4MC.py...
+==> Verifying file 5500/demoanalyzer_cfg_level4MC.py...
   -> Expected size 3874, found 3874
   -> Expected checksum adler32:9cbd53a3, found adler32:9cbd53a3
-==> Verifying file demoanalyzer_cfg_level4data.py...
+==> Verifying file 5500/demoanalyzer_cfg_level4data.py...
   -> Expected size 3821, found 3821
   -> Expected checksum adler32:177b49c0, found adler32:177b49c0
-==> Verifying file mass4l_combine.pdf...
+==> Verifying file 5500/mass4l_combine.pdf...
   -> Expected size 18170, found 18170
   -> Expected checksum adler32:19c6a6a2, found adler32:19c6a6a2
-==> Verifying file mass4l_combine.png...
+==> Verifying file 5500/mass4l_combine.png...
   -> Expected size 93152, found 93152
   -> Expected checksum adler32:62e0c299, found adler32:62e0c299
 ==> Success!
 ```
 
-Note that you can verify each file \"just in time\" as it is being downloaded as
-well:
+Each file is verified just in time as it is downloaded. The explicit `--verify`
+spelling remains available, although it is now the default:
 
 ```console
 $ cernopendata-client download-files --recid 5500 --filter-range 1-4 --verify
 ==> Downloading file 1 of 4
   -> File: ./5500/BuildFile.xml
-==> Verifying file BuildFile.xml...
+==> Verifying file 5500/BuildFile.xml...
   -> Expected size 305, found 305
   -> Expected checksum adler32:ff63668a, found adler32:ff63668a
 ==> Downloading file 2 of 4
   -> File: ./5500/HiggsDemoAnalyzer.cc
-==> Verifying file HiggsDemoAnalyzer.cc...
+==> Verifying file 5500/HiggsDemoAnalyzer.cc...
   -> Expected size 83761, found 83761
   -> Expected checksum adler32:f205f068, found adler32:f205f068
 ==> Downloading file 3 of 4
   -> File: ./5500/List_indexfile.txt
-==> Verifying file List_indexfile.txt...
+==> Verifying file 5500/List_indexfile.txt...
   -> Expected size 1669, found 1669
   -> Expected checksum adler32:46a907fc, found adler32:46a907fc
 ==> Downloading file 4 of 4
   -> File: ./5500/M4Lnormdatall.cc
-==> Verifying file M4Lnormdatall.cc...
+==> Verifying file 5500/M4Lnormdatall.cc...
   -> Expected size 14943, found 14943
   -> Expected checksum adler32:af301992, found adler32:af301992
 ==> Success!

--- a/tests/test_cli_download_files.py
+++ b/tests/test_cli_download_files.py
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020, 2021, 2025 CERN.
+# Copyright (C) 2020, 2021, 2025, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -10,11 +10,146 @@
 """cernopendata-client cli command download-files test."""
 
 import os
+import zlib
 
 import pytest
 
+from cernopendata_client import verifier
 from cernopendata_client.cli import download_files
 from cernopendata_client.config import SERVER_HTTPS_URI
+from cernopendata_client.searcher import FileEntry
+
+
+def _checksum(content):
+    """Return the metadata checksum for test content."""
+    return "adler32:{:08x}".format(zlib.adler32(content, 1) & 0xFFFFFFFF)
+
+
+def _mock_download_command(mocker, entries, content_by_location):
+    """Mock metadata lookup and write requested content like a downloader."""
+    record = mocker.patch(
+        "cernopendata_client.cli.get_record_as_json",
+        return_value={"metadata": {"recid": "42"}},
+    )
+    file_entries = mocker.patch(
+        "cernopendata_client.cli.get_file_entries", return_value=entries
+    )
+
+    def write_download(**kwargs):
+        content = content_by_location.get(kwargs["file_location"])
+        if content is not None:
+            destination = os.path.join(
+                kwargs["path"], kwargs["file_location"].rsplit("/", 1)[-1]
+            )
+            with open(destination, "wb") as stream:
+                stream.write(content)
+
+    downloader = mocker.patch(
+        "cernopendata_client.cli.download_single_file", side_effect=write_download
+    )
+    return record, file_entries, downloader
+
+
+@pytest.mark.local
+def test_download_files_verifies_checksum_by_default(
+    cli_runner, tmp_path, monkeypatch, mocker
+):
+    """Test same-sized corrupt content cannot report success by default."""
+    monkeypatch.chdir(tmp_path)
+    location = "http://example.com/data.bin"
+    entry = FileEntry(location, 4, _checksum(b"good"))
+    record, file_entries, _ = _mock_download_command(
+        mocker, [entry], {location: b"evil"}
+    )
+
+    result = cli_runner.invoke(download_files, ["--recid", "42"])
+
+    assert result.exit_code == 1
+    assert "File checksum does not match" in result.output
+    assert "Success!" not in result.output
+    record.assert_called_once_with("http://opendata.cern.ch", 42, None, None)
+    file_entries.assert_called_once()
+
+
+@pytest.mark.local
+def test_download_files_no_verify_skips_only_checksum(
+    cli_runner, tmp_path, monkeypatch, mocker
+):
+    """Test --no-verify accepts same-sized content without hashing it."""
+    monkeypatch.chdir(tmp_path)
+    location = "http://example.com/data.bin"
+    entry = FileEntry(location, 4, _checksum(b"good"))
+    _mock_download_command(mocker, [entry], {location: b"evil"})
+    checksum = mocker.spy(verifier, "get_file_checksum")
+
+    result = cli_runner.invoke(download_files, ["--recid", "42", "--no-verify"])
+
+    assert result.exit_code == 0
+    assert result.output.endswith("\n==> Success!\n")
+    checksum.assert_not_called()
+
+
+@pytest.mark.local
+def test_download_files_no_verify_rejects_truncated_file(
+    cli_runner, tmp_path, monkeypatch, mocker
+):
+    """Test --no-verify retains always-on expected-size validation."""
+    monkeypatch.chdir(tmp_path)
+    location = "http://example.com/data.bin"
+    entry = FileEntry(location, 10, _checksum(b"complete!!"))
+    _mock_download_command(mocker, [entry], {location: b"short"})
+
+    result = cli_runner.invoke(download_files, ["--recid", "42", "--no-verify"])
+
+    assert result.exit_code == 1
+    assert "Expected size 10, found 5" in result.output
+    assert "incomplete" in result.output
+    assert "Success!" not in result.output
+
+
+@pytest.mark.local
+def test_download_files_rejects_missing_engine_output(
+    cli_runner, tmp_path, monkeypatch, mocker
+):
+    """Test an engine returning without a destination cannot report success."""
+    monkeypatch.chdir(tmp_path)
+    location = "http://example.com/data.bin"
+    entry = FileEntry(location, 4, _checksum(b"data"))
+    _mock_download_command(mocker, [entry], {})
+
+    result = cli_runner.invoke(download_files, ["--recid", "42"])
+
+    assert result.exit_code == 1
+    assert "Downloaded file is missing" in result.output
+    assert "Success!" not in result.output
+
+
+@pytest.mark.local
+def test_download_files_unexpanded_index_is_explicitly_excluded(
+    cli_runner, tmp_path, monkeypatch, mocker
+):
+    """Test aggregate metadata is not compared to an index JSON response."""
+    monkeypatch.chdir(tmp_path)
+    location = "http://example.com/record/42/file_index/index.json"
+    entry = FileEntry(location, 1000000, "", is_file_index=True)
+    _mock_download_command(mocker, [entry], {location: b"{}"})
+
+    result = cli_runner.invoke(download_files, ["--recid", "42", "--no-expand"])
+
+    assert result.exit_code == 0
+    assert "Skipping metadata size and checksum checks" in result.output
+    assert result.output.index("Verifying file") < result.output.index("Skipping")
+    assert result.output.endswith("\n==> Success!\n")
+
+
+@pytest.mark.local
+def test_download_files_help_describes_default_verification(cli_runner):
+    """Test CLI help exposes both verification choices and the default."""
+    result = cli_runner.invoke(download_files, ["--help"])
+
+    assert result.exit_code == 0
+    assert "--verify / --no-verify" in result.output
+    assert "default=yes" in result.output
 
 
 def test_dry_run_from_recid(cli_runner):

--- a/tests/test_cli_verify_files.py
+++ b/tests/test_cli_verify_files.py
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020, 2025 CERN.
+# Copyright (C) 2020, 2025, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -10,11 +10,62 @@
 """cernopendata-client verify-files tests."""
 
 import os
+import zlib
 
 import pytest
 
 from cernopendata_client.cli import download_files, verify_files
 from cernopendata_client.config import SERVER_HTTPS_URI
+from cernopendata_client.searcher import FileEntry
+
+
+def _checksum(content):
+    """Return the metadata checksum for test content."""
+    return "adler32:{:08x}".format(zlib.adler32(content, 1) & 0xFFFFFFFF)
+
+
+@pytest.mark.local
+def test_verify_files_uses_exact_nested_destinations(
+    cli_runner, tmp_path, monkeypatch, mocker
+):
+    """Test duplicate basenames are verified in their exact subdirectories."""
+    monkeypatch.chdir(tmp_path)
+    first_content = b"first"
+    second_content = b"second"
+    entries = [
+        FileEntry(
+            "http://example.com/data/0001/data.root",
+            len(first_content),
+            _checksum(first_content),
+        ),
+        FileEntry(
+            "http://example.com/data/0002/data.root",
+            len(second_content),
+            _checksum(second_content),
+        ),
+    ]
+    first = tmp_path / "42" / "0001" / "data.root"
+    second = tmp_path / "42" / "0002" / "data.root"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    first.write_bytes(first_content)
+    second.write_bytes(second_content)
+    record = mocker.patch(
+        "cernopendata_client.cli.get_record_as_json",
+        return_value={"metadata": {"recid": "42"}},
+    )
+    file_entries = mocker.patch(
+        "cernopendata_client.cli.get_file_entries", return_value=entries
+    )
+
+    result = cli_runner.invoke(verify_files, ["--recid", "42"])
+
+    assert result.exit_code == 0
+    assert "42/0001/data.root" in result.output
+    assert "42/0002/data.root" in result.output
+    assert result.output.endswith("\n==> Success!\n")
+    record.assert_called_once()
+    file_entries.assert_called_once()
 
 
 def test_verify_files(cli_runner):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -12,11 +12,127 @@
 import pytest
 
 from cernopendata_client.downloader import (
+    check_error,
+    download_single_file,
     get_download_files_by_name,
     get_download_files_by_regexp,
     get_download_files_by_range,
+    get_download_items,
     get_file_subdirectories,
 )
+from cernopendata_client.searcher import FileEntry
+
+
+@pytest.mark.local
+def test_check_error_retry_retains_download_engine(tmp_path, mocker):
+    """Test the known-error-page retry uses the selected engine."""
+    error_page = mocker.patch(
+        "cernopendata_client.downloader._is_download_error_page",
+        side_effect=[True, False],
+    )
+    download = mocker.patch("cernopendata_client.downloader.download_single_file")
+    mocker.patch("cernopendata_client.downloader.time.sleep")
+
+    assert (
+        check_error(
+            path=str(tmp_path),
+            file_location="https://example.com/data.bin",
+            protocol="https",
+            retry_limit=2,
+            retry_sleep=1,
+            download_engine="requests",
+        )
+        is True
+    )
+    assert error_page.call_count == 2
+    download.assert_called_once_with(
+        path=str(tmp_path),
+        file_location="https://example.com/data.bin",
+        protocol="https",
+        download_engine="requests",
+    )
+
+
+@pytest.mark.local
+@pytest.mark.parametrize(
+    "existing_size, expected_size, expected_mode, expected_offset",
+    [(3, 10, "ab", 3), (10, 10, "wb", None), (11, 10, "wb", None)],
+)
+def test_download_single_file_uses_metadata_for_resume(
+    tmp_path,
+    mocker,
+    existing_size,
+    expected_size,
+    expected_mode,
+    expected_offset,
+):
+    """Test HTTP resume decisions use record metadata without a HEAD request."""
+    file_location = "https://example.com/data.bin"
+    (tmp_path / "data.bin").write_bytes(b"x" * existing_size)
+    head = mocker.patch("cernopendata_client.downloader.requests.head")
+    downloader = mocker.patch("cernopendata_client.downloader.DownloaderHttpRequests")
+
+    download_single_file(
+        path=str(tmp_path),
+        file_location=file_location,
+        protocol="https",
+        download_engine="requests",
+        expected_size=expected_size,
+    )
+
+    head.assert_not_called()
+    downloader.assert_called_once_with(
+        str(tmp_path), file_location, expected_mode, expected_offset
+    )
+    downloader.return_value.file_downloader.assert_called_once_with()
+
+
+@pytest.mark.local
+def test_get_download_items_preserves_exact_duplicate_destinations():
+    """Test duplicate basenames map to distinct exact paths with metadata."""
+    entries = [
+        FileEntry("http://example.com/0001/data.root", 5, "checksum-one"),
+        FileEntry("http://example.com/0002/data.root", 6, "checksum-two"),
+    ]
+
+    items = get_download_items("42", entries)
+
+    assert items[0].destination_path == "42/0001/data.root"
+    assert items[0].expected_size == 5
+    assert items[0].expected_checksum == "checksum-one"
+    assert items[1].destination_path == "42/0002/data.root"
+    assert items[1].expected_size == 6
+    assert items[1].expected_checksum == "checksum-two"
+
+
+@pytest.mark.local
+def test_get_download_items_uses_full_layout_for_filtered_entry():
+    """Test filtered downloads retain the full record's destination layout."""
+    entries = [
+        FileEntry("http://example.com/0001/data.root", 5, "checksum-one"),
+        FileEntry("http://example.com/0002/data.root", 6, "checksum-two"),
+    ]
+
+    item = get_download_items("42", [entries[0]], layout_entries=entries)[0]
+
+    assert item.destination_path == "42/0001/data.root"
+
+
+@pytest.mark.local
+def test_get_download_items_excludes_unexpanded_index_metadata():
+    """Test aggregate index metadata is not applied to the index document."""
+    entry = FileEntry(
+        "http://example.com/record/42/file_index/index.json",
+        1000000,
+        "",
+        is_file_index=True,
+    )
+
+    item = get_download_items("42", [entry])[0]
+
+    assert item.expected_size is None
+    assert item.expected_checksum is None
+    assert item.is_file_index is True
 
 
 @pytest.mark.local

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of cernopendata-client.
+#
+# Copyright (C) 2026 CERN.
+#
+# cernopendata-client is free software; you can redistribute it and/or modify
+# it under the terms of the GPLv3 license; see LICENSE file for more details.
+
+"""cernopendata-client searcher unit tests."""
+
+import pytest
+
+from cernopendata_client.searcher import get_file_entries, get_files_list
+
+
+@pytest.fixture
+def record_with_file_index():
+    """Return representative direct-file and file-index metadata."""
+    return {
+        "metadata": {
+            "recid": "42",
+            "files": [
+                {
+                    "uri": "root://eospublic.cern.ch//eos/direct.txt",
+                    "size": 6,
+                    "checksum": "adler32:087e0289",
+                }
+            ],
+            "_file_indices": [
+                {
+                    "key": "index.json",
+                    "size": 1000000,
+                    "files": [
+                        {
+                            "uri": "root://eospublic.cern.ch//eos/0001/data.root",
+                            "size": 5,
+                            "checksum": "adler32:062c0215",
+                        },
+                        {
+                            "uri": "root://eospublic.cern.ch//eos/0002/data.root",
+                            "size": 6,
+                            "checksum": "adler32:08ca027d",
+                        },
+                    ],
+                }
+            ],
+        }
+    }
+
+
+@pytest.mark.local
+def test_get_file_entries_marks_only_unexpanded_index(record_with_file_index):
+    """Test expanded files retain normal size and checksum verification."""
+    entries = get_file_entries(
+        "http://opendata.cern.ch",
+        record_with_file_index,
+        protocol="http",
+        expand=True,
+    )
+
+    assert len(entries) == 3
+    assert all(not entry.is_file_index for entry in entries)
+    assert [entry.size for entry in entries] == [6, 5, 6]
+
+
+@pytest.mark.local
+def test_get_file_entries_marks_unexpanded_index(record_with_file_index):
+    """Test a synthetic file-index response has an explicit origin marker."""
+    entries = get_file_entries(
+        "http://opendata.cern.ch",
+        record_with_file_index,
+        protocol="http",
+        expand=False,
+    )
+
+    assert len(entries) == 2
+    assert entries[1].is_file_index is True
+    assert entries[1].size == 1000000
+    assert entries[1].checksum == ""
+    assert entries[1].uri.endswith("/record/42/file_index/index.json")
+
+
+@pytest.mark.local
+def test_get_files_list_preserves_public_tuple_shape(record_with_file_index):
+    """Test the public file-list helper remains backwards compatible."""
+    files = get_files_list(
+        "http://opendata.cern.ch",
+        record_with_file_index,
+        protocol="http",
+        expand=False,
+    )
+
+    assert all(isinstance(file_info, tuple) for file_info in files)
+    assert all(len(file_info) == 3 for file_info in files)
+
+
+@pytest.mark.local
+def test_get_file_entries_allows_missing_checksum():
+    """Test files without checksum metadata still receive size validation."""
+    record = {
+        "metadata": {
+            "recid": "42",
+            "files": [{"uri": "root://eospublic.cern.ch//eos/data.bin", "size": 4}],
+        }
+    }
+
+    entry = get_file_entries(
+        "http://opendata.cern.ch", record, protocol="http", expand=True
+    )[0]
+
+    assert entry.size == 4
+    assert entry.checksum == ""

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -2,7 +2,7 @@
 #
 # This file is part of cernopendata-client.
 #
-# Copyright (C) 2020, 2021, 2025 CERN.
+# Copyright (C) 2020, 2021, 2025, 2026 CERN.
 #
 # cernopendata-client is free software; you can redistribute it and/or modify
 # it under the terms of the GPLv3 license; see LICENSE file for more details.
@@ -12,15 +12,18 @@
 import os
 import subprocess
 import tempfile
+import zlib
 
 import pytest
 import requests
 
 from cernopendata_client.cli import download_files, verify_files
 from cernopendata_client.verifier import (
+    CHECKSUM_CHUNK_SIZE,
     get_file_size,
     get_file_checksum,
     get_file_info_local,
+    verify_downloaded_file,
     verify_file_info,
 )
 
@@ -37,6 +40,92 @@ def test_get_file_checksum():
     """Test get_file_checksum()."""
     afile = "./tests/test_version.py"
     assert get_file_checksum(afile) == "adler32:41cdd471"
+
+
+@pytest.mark.local
+def test_get_file_checksum_reads_in_chunks(mocker):
+    """Test get_file_checksum() uses bounded reads."""
+    content = b"a" * (CHECKSUM_CHUNK_SIZE * 2 + 17)
+    expected = "adler32:{:08x}".format(zlib.adler32(content, 1) & 0xFFFFFFFF)
+    reader = mocker.mock_open(read_data=content).return_value
+
+    mocker.patch("builtins.open", return_value=reader)
+
+    assert get_file_checksum("large-file") == expected
+    assert reader.read.call_count == 4
+    assert all(
+        call.args == (CHECKSUM_CHUNK_SIZE,) for call in reader.read.call_args_list
+    )
+
+
+@pytest.mark.local
+@pytest.mark.parametrize(
+    "content, expected_size, failure",
+    [(b"short", 10, "incomplete"), (b"too long", 3, "oversized")],
+)
+def test_verify_downloaded_file_rejects_wrong_size(
+    tmp_path, capsys, content, expected_size, failure
+):
+    """Test exact-file verification rejects truncated and oversized files."""
+    destination = tmp_path / "data.bin"
+    destination.write_bytes(content)
+
+    with pytest.raises(SystemExit) as exc_info:
+        verify_downloaded_file(destination, expected_size=expected_size)
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr().out
+    assert "Expected size {}, found {}".format(expected_size, len(content)) in output
+    assert failure in output
+
+
+@pytest.mark.local
+def test_verify_downloaded_file_rejects_missing_destination(tmp_path, capsys):
+    """Test exact-file verification reports a missing engine output cleanly."""
+    destination = tmp_path / "missing.bin"
+
+    with pytest.raises(SystemExit) as exc_info:
+        verify_downloaded_file(destination, expected_size=10)
+
+    assert exc_info.value.code == 1
+    assert "Downloaded file is missing" in capsys.readouterr().out
+
+
+@pytest.mark.local
+def test_verify_downloaded_file_can_skip_checksum(tmp_path, mocker):
+    """Test disabling checksums retains the expected-size check."""
+    destination = tmp_path / "data.bin"
+    destination.write_bytes(b"data")
+    checksum = mocker.patch("cernopendata_client.verifier.get_file_checksum")
+
+    assert (
+        verify_downloaded_file(
+            destination,
+            expected_size=4,
+            expected_checksum="adler32:00000000",
+            verify_checksum=False,
+        )
+        is True
+    )
+    checksum.assert_not_called()
+
+
+@pytest.mark.local
+def test_verify_downloaded_empty_file_without_checksum(tmp_path, mocker):
+    """Test zero-sized files with absent checksums still receive a size check."""
+    destination = tmp_path / "empty.bin"
+    destination.touch()
+    checksum = mocker.patch("cernopendata_client.verifier.get_file_checksum")
+
+    assert (
+        verify_downloaded_file(
+            destination,
+            expected_size=0,
+            expected_checksum="",
+        )
+        is True
+    )
+    checksum.assert_not_called()
 
 
 def test_get_file_checksum_zero_padding():


### PR DESCRIPTION
Carry record metadata through file selection and destination mapping so
each download is checked against its exact local path without extra
metadata or HEAD requests. Always reject missing, incomplete, and
oversized files. Verify Adler-32 checksums by default while allowing
--no-verify to skip only the checksum pass.

Cover direct files, expanded file indices, filters, duplicate
basenames, and all download engines through the same verification path.
Derive duplicate-basename layouts from the complete record even for
filtered selections so successive downloads cannot overwrite each other.
Explicitly skip size and checksum comparisons for unexpanded index
responses because their metadata size describes the aggregate indexed
data rather than the JSON document.

Calculate checksums incrementally and make standalone verification
recursive. Retain the selected engine during known-error-page retries.
Document the new default and add local and live regression coverage.

Closes #185
